### PR TITLE
Fix GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -3,12 +3,16 @@ name: Update data
 on:
   push:
     branches: [main]
+permissions:
+  contents: write
 
 jobs:
   fetch:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- add `permissions: contents: write` to the update-data workflow
- explicitly pass `${{ github.token }}` to `actions/checkout`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile scripts/fetch_method.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685876f6856c832f89c23d99c6ca62b8