### PR TITLE
Improve scraper parsing and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Warcraft Rumble Data Extractor
 
 Dieses Skript lädt die aktuellen Minis von [method.gg](https://www.method.gg/warcraft-rumble/minis) und speichert sie als `data/units.json`.
+Der Scraper durchsucht dabei alle `div.mini-wrapper` Elemente auf der Minis-Liste.
 
 ## Setup
 

--- a/data/units.json
+++ b/data/units.json
@@ -1,1 +1,746 @@
-[]
+[
+  {
+    "id": "abomination",
+    "name": "Abomination",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 6,
+    "image": "/images/rumble/minis/300/abomination.png"
+  },
+  {
+    "id": "ancient-of-war",
+    "name": "Ancient of War",
+    "faction": "Cenarion",
+    "type": "Troop",
+    "cost": 0,
+    "image": "/images/rumble/minis/300/ancient-of-war.png"
+  },
+  {
+    "id": "angry-chickens",
+    "name": "Angry Chickens",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/angry-chickens.png"
+  },
+  {
+    "id": "anub'arak",
+    "name": "Anub'arak",
+    "faction": "Beast,Undead",
+    "type": "Leader",
+    "cost": 6,
+    "image": "/images/rumble/minis/300/anub-arak.png"
+  },
+  {
+    "id": "arcane-blast",
+    "name": "Arcane Blast",
+    "faction": "Alliance",
+    "type": "Spell",
+    "cost": 1,
+    "image": "/images/rumble/minis/300/arcane-blast.png"
+  },
+  {
+    "id": "arthas",
+    "name": "Arthas",
+    "faction": "Alliance,Undead",
+    "type": "Leader",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/arthas.png"
+  },
+  {
+    "id": "banshee",
+    "name": "Banshee",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/banshee.png"
+  },
+  {
+    "id": "baron-rivendare",
+    "name": "Baron Rivendare",
+    "faction": "Undead",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/baron-rivendare.png"
+  },
+  {
+    "id": "bat-rider",
+    "name": "Bat Rider",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/bat-rider.png"
+  },
+  {
+    "id": "blizzard",
+    "name": "Blizzard",
+    "faction": "Alliance",
+    "type": "Spell",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/blizzard.png"
+  },
+  {
+    "id": "bloodmage-thalnos",
+    "name": "Bloodmage Thalnos",
+    "faction": "Undead",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/bloodmage-thalnos.png"
+  },
+  {
+    "id": "bog-beast",
+    "name": "Bog Beast",
+    "faction": "Cenarion",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/bog-beast.png"
+  },
+  {
+    "id": "cairne-bloodhoof",
+    "name": "Cairne Bloodhoof",
+    "faction": "Horde",
+    "type": "Leader",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/cairne-bloodhoof.png"
+  },
+  {
+    "id": "cenarius",
+    "name": "Cenarius",
+    "faction": "Cenarion",
+    "type": "Leader",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/cenarius.png"
+  },
+  {
+    "id": "chain-lightning",
+    "name": "Chain Lightning",
+    "faction": "Horde",
+    "type": "Spell",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/chain-lightning.png"
+  },
+  {
+    "id": "charlga-razorflank",
+    "name": "Charlga Razorflank",
+    "faction": "Beast",
+    "type": "Leader",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/charlga-razorflank.png"
+  },
+  {
+    "id": "cheat-death",
+    "name": "Cheat Death",
+    "faction": "Undead",
+    "type": "Spell",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/cheat-death.png"
+  },
+  {
+    "id": "chimaera",
+    "name": "Chimaera",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/chimaera.png"
+  },
+  {
+    "id": "core-hounds",
+    "name": "Core Hounds",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 6,
+    "image": "/images/rumble/minis/300/core-hounds.png"
+  },
+  {
+    "id": "dark-iron-miner",
+    "name": "Dark Iron Miner",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/dark-iron-miner.png"
+  },
+  {
+    "id": "darkspear-troll",
+    "name": "Darkspear Troll",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/darkspear-troll.png"
+  },
+  {
+    "id": "deep-breath",
+    "name": "Deep Breath",
+    "faction": "Blackrock",
+    "type": "Spell",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/deep-breath.png"
+  },
+  {
+    "id": "defias-bandits",
+    "name": "Defias Bandits",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 1,
+    "image": "/images/rumble/minis/300/defias-bandits.png"
+  },
+  {
+    "id": "dire-batlings",
+    "name": "Dire Batlings",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/dire-batlings.png"
+  },
+  {
+    "id": "drake",
+    "name": "Drake",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/drake.png"
+  },
+  {
+    "id": "druid-of-the-claw",
+    "name": "Druid of the Claw",
+    "faction": "Cenarion",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/druid-of-the-claw.png"
+  },
+  {
+    "id": "dryad",
+    "name": "Dryad",
+    "faction": "Cenarion",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/dryad.png"
+  },
+  {
+    "id": "earth-and-moon",
+    "name": "Earth and Moon",
+    "faction": "Cenarion",
+    "type": "Spell",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/earth-and-moon.png"
+  },
+  {
+    "id": "earth-elemental",
+    "name": "Earth Elemental",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/earth-elemental.png"
+  },
+  {
+    "id": "eclipse",
+    "name": "Eclipse",
+    "faction": "Cenarion",
+    "type": "Spell",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/eclipse.png"
+  },
+  {
+    "id": "emperor-thaurissan",
+    "name": "Emperor Thaurissan",
+    "faction": "Blackrock",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/emperor-thaurissan.png"
+  },
+  {
+    "id": "execute",
+    "name": "Execute",
+    "faction": "Horde",
+    "type": "Spell",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/execute.png"
+  },
+  {
+    "id": "faerie-dragon",
+    "name": "Faerie Dragon",
+    "faction": "Cenarion",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/faerie-dragon.png"
+  },
+  {
+    "id": "fire-elemental",
+    "name": "Fire Elemental",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/fire-elemental.png"
+  },
+  {
+    "id": "firehammer",
+    "name": "Firehammer",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/firehammer.png"
+  },
+  {
+    "id": "flamewaker",
+    "name": "Flamewaker",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/flamewaker.png"
+  },
+  {
+    "id": "footmen",
+    "name": "Footmen",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/footmen.png"
+  },
+  {
+    "id": "frostwolf-shaman",
+    "name": "Frostwolf Shaman",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/frostwolf-shaman.png"
+  },
+  {
+    "id": "gargoyle",
+    "name": "Gargoyle",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/gargoyle.png"
+  },
+  {
+    "id": "general-drakkisath",
+    "name": "General Drakkisath",
+    "faction": "Blackrock",
+    "type": "Leader",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/general-drakkisath.png"
+  },
+  {
+    "id": "ghoul",
+    "name": "Ghoul",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/ghoul.png"
+  },
+  {
+    "id": "gnoll-brute",
+    "name": "Gnoll Brute",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/gnoll-brute.png"
+  },
+  {
+    "id": "goblin-sapper",
+    "name": "Goblin Sapper",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/goblin-sapper.png"
+  },
+  {
+    "id": "grommash-hellscream",
+    "name": "Grommash Hellscream",
+    "faction": "Horde",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/grommash-hellscream.png"
+  },
+  {
+    "id": "gryphon-rider",
+    "name": "Gryphon Rider",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/gryphon-rider.png"
+  },
+  {
+    "id": "harpies",
+    "name": "Harpies",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/harpies.png"
+  },
+  {
+    "id": "harvest-golem",
+    "name": "Harvest Golem",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/harvest-golem.png"
+  },
+  {
+    "id": "headless-horseman",
+    "name": "Headless Horseman",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/headless-horseman.png"
+  },
+  {
+    "id": "hogger",
+    "name": "Hogger",
+    "faction": "Beast",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/hogger.png"
+  },
+  {
+    "id": "holy-nova",
+    "name": "Holy Nova",
+    "faction": "Alliance",
+    "type": "Spell",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/holy-nova.png"
+  },
+  {
+    "id": "huntress",
+    "name": "Huntress",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/huntress.png"
+  },
+  {
+    "id": "jaina-proudmoore",
+    "name": "Jaina Proudmoore",
+    "faction": "Alliance",
+    "type": "Leader",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/jaina-proudmoore.png"
+  },
+  {
+    "id": "living-bomb",
+    "name": "Living Bomb",
+    "faction": "Blackrock",
+    "type": "Spell",
+    "cost": 6,
+    "image": "/images/rumble/minis/300/living-bomb.png"
+  },
+  {
+    "id": "maiev-shadowsong",
+    "name": "Maiev Shadowsong",
+    "faction": "Alliance",
+    "type": "Leader",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/maiev-shadowsong.png"
+  },
+  {
+    "id": "malfurion",
+    "name": "Malfurion",
+    "faction": "Alliance,Cenarion",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/malfurion.png"
+  },
+  {
+    "id": "meat-wagon",
+    "name": "Meat Wagon",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/meat-wagon.png"
+  },
+  {
+    "id": "molten-giant",
+    "name": "Molten Giant",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 6,
+    "image": "/images/rumble/minis/300/molten-giant.png"
+  },
+  {
+    "id": "moonkin",
+    "name": "Moonkin",
+    "faction": "Cenarion",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/moonkin.png"
+  },
+  {
+    "id": "mountaineer",
+    "name": "Mountaineer",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/mountaineer.png"
+  },
+  {
+    "id": "murloc-tidehunters",
+    "name": "Murloc Tidehunters",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/murloc-tidehunters.png"
+  },
+  {
+    "id": "necromancer",
+    "name": "Necromancer",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/necromancer.png"
+  },
+  {
+    "id": "ogre-mage",
+    "name": "Ogre Mage",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/ogre-mage.png"
+  },
+  {
+    "id": "old-murk-eye",
+    "name": "Old Murk-Eye",
+    "faction": "Beast",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/old-murk-eye.png"
+  },
+  {
+    "id": "onu",
+    "name": "Onu",
+    "faction": "Cenarion",
+    "type": "Leader",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/onu.png"
+  },
+  {
+    "id": "orgrim-doomhammer",
+    "name": "Orgrim Doomhammer",
+    "faction": "Blackrock,Horde",
+    "type": "Leader",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/orgrim-doomhammer.png"
+  },
+  {
+    "id": "plague-farmer",
+    "name": "Plague Farmer",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/plague-farmer.png"
+  },
+  {
+    "id": "polymorph",
+    "name": "Polymorph",
+    "faction": "Beast",
+    "type": "Spell",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/polymorph.png"
+  },
+  {
+    "id": "priestess",
+    "name": "Priestess",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/priestess.png"
+  },
+  {
+    "id": "prowler",
+    "name": "Prowler",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/prowler.png"
+  },
+  {
+    "id": "pyromancer",
+    "name": "Pyromancer",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/pyromancer.png"
+  },
+  {
+    "id": "quilboar",
+    "name": "Quilboar",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/quilboar.png"
+  },
+  {
+    "id": "ragnaros",
+    "name": "Ragnaros",
+    "faction": "Blackrock",
+    "type": "Leader",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/ragnaros.png"
+  },
+  {
+    "id": "raptors",
+    "name": "Raptors",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/raptors.png"
+  },
+  {
+    "id": "rend-blackhand",
+    "name": "Rend Blackhand",
+    "faction": "Blackrock",
+    "type": "Leader",
+    "cost": 6,
+    "image": "/images/rumble/minis/300/rend-blackhand.png"
+  },
+  {
+    "id": "s.a.f.e.-pilot",
+    "name": "S.A.F.E. Pilot",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/s-a-f-e-pilot.png"
+  },
+  {
+    "id": "skeleton-party",
+    "name": "Skeleton Party",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/skeleton-party.png"
+  },
+  {
+    "id": "skeletons",
+    "name": "Skeletons",
+    "faction": "Undead",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/skeletons.png"
+  },
+  {
+    "id": "smoke-bomb",
+    "name": "Smoke Bomb",
+    "faction": "Blackrock",
+    "type": "Spell",
+    "cost": 1,
+    "image": "/images/rumble/minis/300/smoke-bomb.png"
+  },
+  {
+    "id": "sneed",
+    "name": "Sneed",
+    "faction": "Horde",
+    "type": "Leader",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/sneed.png"
+  },
+  {
+    "id": "spiderlings",
+    "name": "Spiderlings",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/spiderlings.png"
+  },
+  {
+    "id": "stonehoof-tauren",
+    "name": "Stonehoof Tauren",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/stonehoof-tauren.png"
+  },
+  {
+    "id": "swole-troll",
+    "name": "Swole Troll",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/swole-troll.png"
+  },
+  {
+    "id": "sylvanas-windrunner",
+    "name": "Sylvanas Windrunner",
+    "faction": "Horde,Undead",
+    "type": "Leader",
+    "cost": 6,
+    "image": "/images/rumble/minis/300/sylvanas-windrunner.png"
+  },
+  {
+    "id": "thrall",
+    "name": "Thrall",
+    "faction": "Horde",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/thrall.png"
+  },
+  {
+    "id": "tirion-fordring",
+    "name": "Tirion Fordring",
+    "faction": "Alliance",
+    "type": "Leader",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/tirion-fordring.png"
+  },
+  {
+    "id": "treant",
+    "name": "Treant",
+    "faction": "Cenarion",
+    "type": "Troop",
+    "cost": 1,
+    "image": "/images/rumble/minis/300/treant.png"
+  },
+  {
+    "id": "vultures",
+    "name": "Vultures",
+    "faction": "Beast",
+    "type": "Troop",
+    "cost": 1,
+    "image": "/images/rumble/minis/300/vultures.png"
+  },
+  {
+    "id": "warsong-grunts",
+    "name": "Warsong Grunts",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 5,
+    "image": "/images/rumble/minis/300/warsong-grunts.png"
+  },
+  {
+    "id": "warsong-raider",
+    "name": "Warsong Raider",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 4,
+    "image": "/images/rumble/minis/300/warsong-raider.png"
+  },
+  {
+    "id": "whelp-eggs",
+    "name": "Whelp Eggs",
+    "faction": "Blackrock",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/whelp-eggs.png"
+  },
+  {
+    "id": "witch-doctor",
+    "name": "Witch Doctor",
+    "faction": "Horde",
+    "type": "Troop",
+    "cost": 2,
+    "image": "/images/rumble/minis/300/witch-doctor.png"
+  },
+  {
+    "id": "worgen",
+    "name": "Worgen",
+    "faction": "Alliance",
+    "type": "Troop",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/worgen.png"
+  },
+  {
+    "id": "ysera",
+    "name": "Ysera",
+    "faction": "Cenarion",
+    "type": "Leader",
+    "cost": 3,
+    "image": "/images/rumble/minis/300/ysera.png"
+  }
+]

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -1,4 +1,3 @@
-import os
 import json
 import requests
 from bs4 import BeautifulSoup
@@ -9,27 +8,25 @@ OUT_PATH = Path(__file__).parent.parent / "data" / "units.json"
 
 
 def fetch_units():
+    """Fetch the minis list from method.gg and return it as a list of dicts."""
+
     print(f"Starte Abruf von {BASE_URL} ...")
     response = requests.get(BASE_URL, headers={"User-Agent": "Mozilla/5.0"})
     if response.status_code != 200:
         raise Exception(f"Fehler beim Abrufen: {response.status_code}")
 
     soup = BeautifulSoup(response.text, "html.parser")
-    cards = soup.select(".mini-card")
+    cards = soup.select("div.mini-wrapper")
 
     all_units = []
 
     for card in cards:
-        name_elem = card.select_one(".mini-card__name")
-        faction_elem = card.select_one(".mini-card__faction")
-        type_elem = card.select_one(".mini-card__type")
-        cost_elem = card.select_one(".mini-card__elixir")
+        name = card.get("data-name", "?")
+        faction = card.get("data-family", "?")
+        unit_type = card.get("data-type", "?")
+        cost_attr = card.get("data-cost")
+        cost = int(cost_attr) if cost_attr is not None else None
         image_elem = card.select_one("img")
-
-        name = name_elem.text.strip() if name_elem else "?"
-        faction = faction_elem.text.strip() if faction_elem else "?"
-        unit_type = type_elem.text.strip() if type_elem else "?"
-        cost = int(cost_elem.text.strip()) if cost_elem else None
         image_url = image_elem["src"] if image_elem else None
 
         unit_id = name.lower().replace(" ", "-")


### PR DESCRIPTION
## Summary
- parse `div.mini-wrapper` elements instead of deprecated `.mini-card`
- store data-name/type/family/cost attributes and image URL
- remove unused import, add function docstring
- regenerate `units.json`
- mention `.mini-wrapper` in README

## Testing
- `pip install -r requirements.txt`
- `python scripts/fetch_method.py`

------
https://chatgpt.com/codex/tasks/task_e_68587aa7dc68832f8a07e1db87219abd