### PR TITLE
Add test for fetch_units and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ python scripts/fetch_method.py
 ```
 
 Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Datei `data/units.json` automatisch aktualisiert.
+
+## Tests
+
+Die Tests lassen sich mit [pytest](https://pytest.org) ausführen:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import fetch_method
+
+
+def test_fetch_units_writes_json(tmp_path):
+    html = """
+        <div class="mini-wrapper">
+          <div class="mini-card">
+            <div class="mini-card__name">Footman</div>
+            <div class="mini-card__faction">Alliance</div>
+            <div class="mini-card__type">Troop</div>
+            <div class="mini-card__elixir">2</div>
+            <img src="footman.png"/>
+          </div>
+        </div>
+    """
+    mock_response = Mock(status_code=200, text=html)
+    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+        out_file = tmp_path / "units.json"
+        with patch.object(fetch_method, "OUT_PATH", out_file):
+            fetch_method.fetch_units()
+            data = json.loads(Path(out_file).read_text(encoding="utf-8"))
+
+    assert data == [{
+        "id": "footman",
+        "name": "Footman",
+        "faction": "Alliance",
+        "type": "Troop",
+        "cost": 2,
+        "image": "footman.png",
+    }]


### PR DESCRIPTION
## Summary
- add PyTest-based regression test for `fetch_units`
- explain how to run tests in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587aa92ebc832f9900feec69442cde