### PR TITLE
Implement detail scraping for minis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
 # Warcraft Rumble Data Extractor
 
 Dieses Skript lädt die aktuellen Minis von [method.gg](https://www.method.gg/warcraft-rumble/minis) und speichert sie als `data/units.json`.
-Der Scraper durchsucht dabei alle `div.mini-wrapper` Elemente auf der Minis-Liste.
+Der Scraper durchsucht dabei alle `div.mini-wrapper` Elemente auf der Minis-Liste und ruft anschließend die jeweilige Detailseite auf.
+Neben den Basisdaten werden dadurch auch Schaden, Lebenspunkte, DPS, Geschwindigkeit und Traits sowie weitere Detailinformationen erfasst.
 
 ## Setup
 
 ```bash
 pip install -r requirements.txt
 python scripts/fetch_method.py
+```
+
+Der Aufruf legt die Datei `data/units.json` an, die alle Minis mit ihren
+zusätzlichen Feldern enthält. Ein Auszug könnte folgendermaßen aussehen:
+
+```json
+[
+  {
+    "id": "footman",
+    "name": "Footman",
+    "damage": 10,
+    "health": 20,
+    "dps": 5.0,
+    "speed": "Slow",
+    "traits": ["Melee", "One-Target"],
+    "details": {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "..."}
+  }
+]
 ```
 
 Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Datei `data/units.json` automatisch aktualisiert.

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -7,14 +7,106 @@ BASE_URL = "https://www.method.gg/warcraft-rumble/minis"
 OUT_PATH = Path(__file__).parent.parent / "data" / "units.json"
 
 
+def fetch_unit_details(url: str) -> dict:
+    """Fetch and parse the details page for a single mini.
+
+    The returned dictionary contains the sections ``core_trait``,
+    ``stats``, ``traits``, ``talents`` and ``advanced_info`` extracted
+    from the detail page.
+    """
+
+    response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
+    if response.status_code != 200:
+        raise Exception(f"Fehler beim Abrufen: {response.status_code}")
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    def find_section(title: str):
+        h2 = soup.find("h2", string=lambda t: t and t.strip() == title)
+        return h2.find_parent(class_="mini-section") if h2 else None
+
+    details = {}
+
+    # Core Trait information is located in the "Mini Information" block
+    info_section = find_section("Mini Information")
+    core_trait = {}
+    if info_section:
+        for tile in info_section.select(".mini-details-tile"):
+            label_elem = tile.select_one(".detail-label")
+            info_elem = tile.select_one(".detail-info")
+            label = label_elem.get_text(strip=True) if label_elem else None
+            value = info_elem.get_text(strip=True) if info_elem else None
+            if label and label.startswith("Core Trait"):
+                if "Attack" in label:
+                    core_trait["attack"] = value
+                elif "Type" in label:
+                    core_trait["type"] = value
+    if core_trait:
+        details["core_trait"] = core_trait
+
+    # Stats section
+    stats_section = find_section("Stats")
+    stats = {}
+    if stats_section:
+        for tile in stats_section.select(".mini-details-tile"):
+            label_elem = tile.select_one(".detail-label")
+            info_elem = tile.select_one(".detail-info") or tile.select_one(
+                ".mini-stats__upgrade.detail-info"
+            )
+            label = label_elem.get_text(strip=True) if label_elem else None
+            value = info_elem.get_text(strip=True) if info_elem else None
+            if label and value:
+                stats[label] = value
+    if stats:
+        details["stats"] = stats
+
+    # Traits section
+    traits_section = find_section("Traits")
+    traits = []
+    if traits_section:
+        for tile in traits_section.select(".mini-trait-tile"):
+            name_elem = tile.select_one(".detail-info")
+            desc_elem = tile.select_one(".mini-talent__description")
+            name = name_elem.get_text(strip=True) if name_elem else None
+            desc = desc_elem.get_text(strip=True) if desc_elem else None
+            if name:
+                traits.append({"name": name, "description": desc})
+    if traits:
+        details["traits"] = traits
+
+    # Talents section
+    talents_section = find_section("Talents")
+    talents = []
+    if talents_section:
+        for tile in talents_section.select(".mini-trait-tile"):
+            name_elem = tile.select_one(".detail-info")
+            desc_elem = tile.select_one(".mini-talent__description")
+            name = name_elem.get_text(strip=True) if name_elem else None
+            desc = desc_elem.get_text(strip=True) if desc_elem else None
+            if name:
+                talents.append({"name": name, "description": desc})
+    if talents:
+        details["talents"] = talents
+
+    # Advanced Mini Information section
+    adv_section = find_section("Advanced Mini Information")
+    if adv_section:
+        content = adv_section.select_one(".mini-content")
+        if content:
+            details["advanced_info"] = content.get_text("\n", strip=True)
+
+    return details
+
 def fetch_units():
     """Fetch the minis list from method.gg and return it as a list of dicts."""
     """Download minis from method.gg and store them as JSON.
 
     The function retrieves the minis overview from ``method.gg`` and parses
-    name, faction, type, cost and image for each entry. All collected units
-    are written to ``data/units.json``. The file will be created if it does
-    not exist and overwritten otherwise.
+    name, faction, type, cost, image as well as damage, health, dps, speed
+    and traits for each entry. For every mini the corresponding detail page
+    is fetched via :func:`fetch_unit_details` and merged into the output.
+    All collected units are written to ``data/units.json``. The file will be
+    created if it does not exist and overwritten otherwise.
 
     Returns:
         None: Writes the JSON file and prints progress information.
@@ -36,19 +128,42 @@ def fetch_units():
         unit_type = card.get("data-type", "?")
         cost_attr = card.get("data-cost")
         cost = int(cost_attr) if cost_attr is not None else None
+
+        damage_attr = card.get("data-damage")
+        damage = int(float(damage_attr)) if damage_attr is not None else None
+        health_attr = card.get("data-health")
+        health = int(float(health_attr)) if health_attr is not None else None
+        dps_attr = card.get("data-dps")
+        dps = float(dps_attr) if dps_attr is not None else None
+        speed = card.get("data-speed")
+        traits_attr = card.get("data-traits", "")
+        traits = [t.strip() for t in traits_attr.split(",") if t.strip()]
+
+        link = card.select_one("a.mini-link")
+        url = f"https://www.method.gg{link['href']}" if link else None
         image_elem = card.select_one("img")
         image_url = image_elem["src"] if image_elem else None
 
-        unit_id = name.lower().replace(" ", "-")
+        unit_id = (link["href"].split("/")[-1] if link else name).lower().replace(" ", "-")
 
-        all_units.append({
+        details = fetch_unit_details(url) if url else {}
+
+        unit_data = {
             "id": unit_id,
             "name": name,
             "faction": faction,
             "type": unit_type,
             "cost": cost,
-            "image": image_url
-        })
+            "image": image_url,
+            "damage": damage,
+            "health": health,
+            "dps": dps,
+            "speed": speed,
+            "traits": traits,
+            "details": details,
+        }
+
+        all_units.append(unit_data)
 
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(OUT_PATH, "w", encoding="utf-8") as f:

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -10,20 +10,18 @@ from scripts import fetch_method
 
 def test_fetch_units_writes_json(tmp_path):
     html = """
-        <div class="mini-wrapper">
-          <div class="mini-card">
-            <div class="mini-card__name">Footman</div>
-            <div class="mini-card__faction">Alliance</div>
-            <div class="mini-card__type">Troop</div>
-            <div class="mini-card__elixir">2</div>
-            <img src="footman.png"/>
-          </div>
+        <div class="mini-wrapper" data-name="Footman" data-family="Alliance" data-type="Troop" data-cost="2" data-damage="10" data-health="20" data-dps="5" data-speed="Slow" data-traits="Melee,One-Target">
+            <a class="mini-link" href="/warcraft-rumble/minis/footman">
+                <img src="footman.png" />
+            </a>
         </div>
     """
     mock_response = Mock(status_code=200, text=html)
     with patch("scripts.fetch_method.requests.get", return_value=mock_response):
         out_file = tmp_path / "units.json"
-        with patch.object(fetch_method, "OUT_PATH", out_file):
+        dummy_details = {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "info"}
+        with patch.object(fetch_method, "OUT_PATH", out_file), \
+             patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()
             data = json.loads(Path(out_file).read_text(encoding="utf-8"))
 
@@ -34,4 +32,10 @@ def test_fetch_units_writes_json(tmp_path):
         "type": "Troop",
         "cost": 2,
         "image": "footman.png",
+        "damage": 10,
+        "health": 20,
+        "dps": 5.0,
+        "speed": "Slow",
+        "traits": ["Melee", "One-Target"],
+        "details": dummy_details,
     }]


### PR DESCRIPTION
## Summary
- extend `fetch_units` with damage, health, dps, speed and traits
- add `fetch_unit_details` that reads detail page sections
- combine information when writing `units.json`
- adapt unit tests to cover new fields
- document new functionality in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68588015a3f0832fa772988af1bf26dd