### PR TITLE
Add army bonus slots parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,21 @@ zusätzlichen Feldern enthält. Ein Auszug könnte folgendermaßen aussehen:
     "dps": 5.0,
     "speed": "Slow",
     "traits": ["Melee", "One-Target"],
-    "details": {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "..."}
+    "details": {
+      "core_trait": {},
+      "stats": {},
+      "traits": [],
+      "talents": [],
+      "advanced_info": "...",
+      "army_bonus_slots": []
+    }
   }
 ]
 ```
+
+Das optionale Feld `army_bonus_slots` enthält eine Liste der Boni, die eine
+Einheit in der unteren Reihe des Armeefensters gewähren kann, sofern diese
+Information auf der Detailseite vorhanden ist.
 
 Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Datei `data/units.json` automatisch aktualisiert.
 

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -93,7 +93,24 @@ def fetch_unit_details(url: str) -> dict:
     if adv_section:
         content = adv_section.select_one(".mini-content")
         if content:
-            details["advanced_info"] = content.get_text("\n", strip=True)
+            adv_text = content.get_text("\n", strip=True)
+            lines = adv_text.splitlines()
+            prefix = "Available army bonus slots for the bottom row"
+            army_bonus_slots = []
+            for idx, line in enumerate(lines):
+                if line.startswith(prefix):
+                    j = idx + 1
+                    while j < len(lines):
+                        next_line = lines[j]
+                        if next_line == "" or next_line.startswith("Without"):
+                            break
+                        army_bonus_slots.append(next_line.strip())
+                        j += 1
+                    del lines[idx + 1 : j]
+                    break
+            details["advanced_info"] = "\n".join(lines)
+            if army_bonus_slots:
+                details["army_bonus_slots"] = army_bonus_slots
 
     return details
 

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -19,7 +19,14 @@ def test_fetch_units_writes_json(tmp_path):
     mock_response = Mock(status_code=200, text=html)
     with patch("scripts.fetch_method.requests.get", return_value=mock_response):
         out_file = tmp_path / "units.json"
-        dummy_details = {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "info"}
+        dummy_details = {
+            "core_trait": {},
+            "stats": {},
+            "traits": [],
+            "talents": [],
+            "advanced_info": "info",
+            "army_bonus_slots": ["Cycle"],
+        }
         with patch.object(fetch_method, "OUT_PATH", out_file), \
              patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()


### PR DESCRIPTION
## Summary
- parse optional army bonus slots out of the advanced info block
- store the slots list in the details dictionary
- update README with the new field
- adjust tests for the new data

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f862cb3c832f8f696611e7b33910