### PR TITLE
Add category mapping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ pip install -r requirements.txt
 python scripts/fetch_method.py
 ```
 
-Der Aufruf legt die Datei `data/units.json` an, die alle Minis mit ihren
-zusätzlichen Feldern enthält. Ein Auszug könnte folgendermaßen aussehen:
+Der Aufruf legt die Dateien `data/units.json` und `data/categories.json` an.
+`units.json` enthält die Minis, `categories.json` die verfügbaren Fraktionen,
+Typen, Traits und Geschwindigkeiten.
+Ein Auszug aus `units.json` könnte folgendermaßen aussehen:
 
 ```json
 [
@@ -22,14 +24,17 @@ zusätzlichen Feldern enthält. Ein Auszug könnte folgendermaßen aussehen:
     "damage": 10,
     "health": 20,
     "dps": 5.0,
-    "speed": "Slow",
-    "traits": ["Melee", "One-Target"],
+    "speed_id": "slow",
+    "type_id": "troop",
+    "faction_ids": ["alliance"],
+    "trait_ids": ["melee", "one-target"],
     "details": {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "..."}
   }
 ]
 ```
 
-Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Datei `data/units.json` automatisch aktualisiert.
+Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Dateien
+`data/units.json` und `data/categories.json` automatisch aktualisiert.
 
 ## Tests
 

--- a/data/categories.json
+++ b/data/categories.json
@@ -1,0 +1,472 @@
+{
+  "factions": [
+    {
+      "id": "alliance",
+      "names": {
+        "en": "Alliance"
+      },
+      "icon": "/images/rumble/alliance.png",
+      "color": "#4A8CC4"
+    },
+    {
+      "id": "beast",
+      "names": {
+        "en": "Beast"
+      },
+      "icon": "/images/rumble/beast.png",
+      "color": "#B55F28"
+    },
+    {
+      "id": "blackrock",
+      "names": {
+        "en": "Blackrock"
+      },
+      "icon": "/images/rumble/blackrock.png",
+      "color": "#628C8E"
+    },
+    {
+      "id": "cenarion",
+      "names": {
+        "en": "Cenarion"
+      },
+      "icon": "/images/rumble/cenarion.png",
+      "color": "#007D65"
+    },
+    {
+      "id": "horde",
+      "names": {
+        "en": "Horde"
+      },
+      "icon": "/images/rumble/horde.png",
+      "color": "#BC3A28"
+    },
+    {
+      "id": "undead",
+      "names": {
+        "en": "Undead"
+      },
+      "icon": "/images/rumble/undead.png",
+      "color": "#6D59A7"
+    }
+  ],
+  "types": [
+    {
+      "id": "leader",
+      "names": {
+        "en": "Leader"
+      }
+    },
+    {
+      "id": "spell",
+      "names": {
+        "en": "Spell"
+      }
+    },
+    {
+      "id": "troop",
+      "names": {
+        "en": "Troop"
+      }
+    }
+  ],
+  "traits": [
+    {
+      "id": "ambush",
+      "names": {
+        "en": "Ambush"
+      }
+    },
+    {
+      "id": "aoe",
+      "names": {
+        "en": "AoE"
+      }
+    },
+    {
+      "id": "armored",
+      "names": {
+        "en": "Armored"
+      }
+    },
+    {
+      "id": "army-of-the-dead",
+      "names": {
+        "en": "Army of the Dead"
+      }
+    },
+    {
+      "id": "attack-root",
+      "names": {
+        "en": "Attack Root"
+      }
+    },
+    {
+      "id": "attack-stun",
+      "names": {
+        "en": "Attack Stun"
+      }
+    },
+    {
+      "id": "blast-wave",
+      "names": {
+        "en": "Blast Wave"
+      }
+    },
+    {
+      "id": "bloodlust",
+      "names": {
+        "en": "Bloodlust"
+      }
+    },
+    {
+      "id": "bombard",
+      "names": {
+        "en": "Bombard"
+      }
+    },
+    {
+      "id": "brambles",
+      "names": {
+        "en": "Brambles"
+      }
+    },
+    {
+      "id": "braze",
+      "names": {
+        "en": "Braze"
+      }
+    },
+    {
+      "id": "cannibalize",
+      "names": {
+        "en": "Cannibalize"
+      }
+    },
+    {
+      "id": "carrion",
+      "names": {
+        "en": "Carrion"
+      }
+    },
+    {
+      "id": "charge",
+      "names": {
+        "en": "Charge"
+      }
+    },
+    {
+      "id": "cheap-shot",
+      "names": {
+        "en": "Cheap Shot"
+      }
+    },
+    {
+      "id": "cycle",
+      "names": {
+        "en": "Cycle"
+      }
+    },
+    {
+      "id": "detect",
+      "names": {
+        "en": "Detect"
+      }
+    },
+    {
+      "id": "dismounts",
+      "names": {
+        "en": "Dismounts"
+      }
+    },
+    {
+      "id": "earth-and-moon",
+      "names": {
+        "en": "Earth and Moon"
+      }
+    },
+    {
+      "id": "eclipse",
+      "names": {
+        "en": "Eclipse"
+      }
+    },
+    {
+      "id": "elemental",
+      "names": {
+        "en": "Elemental"
+      }
+    },
+    {
+      "id": "fast",
+      "names": {
+        "en": "Fast"
+      }
+    },
+    {
+      "id": "fiery-weapon-enchant",
+      "names": {
+        "en": "Fiery Weapon Enchant"
+      }
+    },
+    {
+      "id": "flying",
+      "names": {
+        "en": "Flying"
+      }
+    },
+    {
+      "id": "frost",
+      "names": {
+        "en": "Frost"
+      }
+    },
+    {
+      "id": "fury",
+      "names": {
+        "en": "Fury"
+      }
+    },
+    {
+      "id": "hatching",
+      "names": {
+        "en": "Hatching"
+      }
+    },
+    {
+      "id": "haunt",
+      "names": {
+        "en": "Haunt"
+      }
+    },
+    {
+      "id": "heal-squadmate",
+      "names": {
+        "en": "Heal Squadmate"
+      }
+    },
+    {
+      "id": "healer",
+      "names": {
+        "en": "Healer"
+      }
+    },
+    {
+      "id": "hook",
+      "names": {
+        "en": "Hook"
+      }
+    },
+    {
+      "id": "lichborne",
+      "names": {
+        "en": "Lichborne"
+      }
+    },
+    {
+      "id": "longshot",
+      "names": {
+        "en": "Longshot"
+      }
+    },
+    {
+      "id": "mak'gora",
+      "names": {
+        "en": "Mak'gora"
+      }
+    },
+    {
+      "id": "melee",
+      "names": {
+        "en": "Melee"
+      }
+    },
+    {
+      "id": "miner",
+      "names": {
+        "en": "Miner"
+      }
+    },
+    {
+      "id": "nullify",
+      "names": {
+        "en": "Nullify"
+      }
+    },
+    {
+      "id": "one-target",
+      "names": {
+        "en": "One-Target"
+      }
+    },
+    {
+      "id": "percent-damage",
+      "names": {
+        "en": "Percent Damage"
+      }
+    },
+    {
+      "id": "poisonous",
+      "names": {
+        "en": "Poisonous"
+      }
+    },
+    {
+      "id": "possession",
+      "names": {
+        "en": "Possession"
+      }
+    },
+    {
+      "id": "ranged",
+      "names": {
+        "en": "Ranged"
+      }
+    },
+    {
+      "id": "rebirth",
+      "names": {
+        "en": "Rebirth"
+      }
+    },
+    {
+      "id": "remorseless-winter",
+      "names": {
+        "en": "Remorseless Winter"
+      }
+    },
+    {
+      "id": "resistant",
+      "names": {
+        "en": "Resistant"
+      }
+    },
+    {
+      "id": "revive",
+      "names": {
+        "en": "Revive"
+      }
+    },
+    {
+      "id": "seeds-of-protection",
+      "names": {
+        "en": "Seeds of Protection"
+      }
+    },
+    {
+      "id": "shapeshift",
+      "names": {
+        "en": "Shapeshift"
+      }
+    },
+    {
+      "id": "siege-damage",
+      "names": {
+        "en": "Siege Damage"
+      }
+    },
+    {
+      "id": "siege-specialist",
+      "names": {
+        "en": "Siege Specialist"
+      }
+    },
+    {
+      "id": "spell",
+      "names": {
+        "en": "Spell"
+      }
+    },
+    {
+      "id": "squad",
+      "names": {
+        "en": "Squad"
+      }
+    },
+    {
+      "id": "stealth",
+      "names": {
+        "en": "Stealth"
+      }
+    },
+    {
+      "id": "summoner",
+      "names": {
+        "en": "Summoner"
+      }
+    },
+    {
+      "id": "surge",
+      "names": {
+        "en": "Surge"
+      }
+    },
+    {
+      "id": "tank",
+      "names": {
+        "en": "Tank"
+      }
+    },
+    {
+      "id": "tranquility",
+      "names": {
+        "en": "Tranquility"
+      }
+    },
+    {
+      "id": "unbound",
+      "names": {
+        "en": "Unbound"
+      }
+    },
+    {
+      "id": "unstoppable",
+      "names": {
+        "en": "Unstoppable"
+      }
+    },
+    {
+      "id": "vulnerable",
+      "names": {
+        "en": "Vulnerable"
+      }
+    }
+  ],
+  "speeds": [
+    {
+      "id": "fast",
+      "names": {
+        "en": "Fast"
+      }
+    },
+    {
+      "id": "med-fast",
+      "names": {
+        "en": "Med-Fast"
+      }
+    },
+    {
+      "id": "medium",
+      "names": {
+        "en": "Medium"
+      }
+    },
+    {
+      "id": "slow",
+      "names": {
+        "en": "Slow"
+      }
+    },
+    {
+      "id": "stationary",
+      "names": {
+        "en": "Stationary"
+      }
+    },
+    {
+      "id": "znull",
+      "names": {
+        "en": "Znull"
+      }
+    }
+  ]
+}

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -5,6 +5,23 @@ from pathlib import Path
 
 BASE_URL = "https://www.method.gg/warcraft-rumble/minis"
 OUT_PATH = Path(__file__).parent.parent / "data" / "units.json"
+CATEGORIES_PATH = Path(__file__).parent.parent / "data" / "categories.json"
+
+
+def load_categories() -> dict:
+    """Load category mappings from :data:`CATEGORIES_PATH`."""
+    with open(CATEGORIES_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+
+    def to_map(items):
+        return {item["names"]["en"]: item["id"] for item in items}
+
+    return {
+        "faction": to_map(data.get("factions", [])),
+        "type": to_map(data.get("types", [])),
+        "trait": to_map(data.get("traits", [])),
+        "speed": to_map(data.get("speeds", [])),
+    }
 
 
 def fetch_unit_details(url: str) -> dict:
@@ -120,11 +137,12 @@ def fetch_units():
     soup = BeautifulSoup(response.text, "html.parser")
     cards = soup.select("div.mini-wrapper")
 
+    cats = load_categories()
     all_units = []
 
     for card in cards:
         name = card.get("data-name", "?")
-        faction = card.get("data-family", "?")
+        faction_val = card.get("data-family", "?")
         unit_type = card.get("data-type", "?")
         cost_attr = card.get("data-cost")
         cost = int(cost_attr) if cost_attr is not None else None
@@ -135,31 +153,38 @@ def fetch_units():
         health = int(float(health_attr)) if health_attr is not None else None
         dps_attr = card.get("data-dps")
         dps = float(dps_attr) if dps_attr is not None else None
-        speed = card.get("data-speed")
+        speed_val = card.get("data-speed")
         traits_attr = card.get("data-traits", "")
-        traits = [t.strip() for t in traits_attr.split(",") if t.strip()]
+        trait_names = [t.strip() for t in traits_attr.split(",") if t.strip()]
 
         link = card.select_one("a.mini-link")
         url = f"https://www.method.gg{link['href']}" if link else None
         image_elem = card.select_one("img")
         image_url = image_elem["src"] if image_elem else None
 
-        unit_id = (link["href"].split("/")[-1] if link else name).lower().replace(" ", "-")
+        unit_id = (
+            link["href"].split("/")[-1] if link else name
+        ).lower().replace(" ", "-")
 
         details = fetch_unit_details(url) if url else {}
+
+        faction_ids = [cats["faction"].get(f, f.lower()) for f in faction_val.split(",") if f]
+        trait_ids = [cats["trait"].get(t, t.lower().replace(" ", "-")) for t in trait_names]
+        type_id = cats["type"].get(unit_type, unit_type.lower())
+        speed_id = cats["speed"].get(speed_val, speed_val.lower()) if speed_val else None
 
         unit_data = {
             "id": unit_id,
             "name": name,
-            "faction": faction,
-            "type": unit_type,
+            "faction_ids": faction_ids,
+            "type_id": type_id,
             "cost": cost,
             "image": image_url,
             "damage": damage,
             "health": health,
             "dps": dps,
-            "speed": speed,
-            "traits": traits,
+            "speed_id": speed_id,
+            "trait_ids": trait_ids,
             "details": details,
         }
 

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -17,10 +17,24 @@ def test_fetch_units_writes_json(tmp_path):
         </div>
     """
     mock_response = Mock(status_code=200, text=html)
+
+    categories = {
+        "factions": [{"id": "alliance", "names": {"en": "Alliance"}}],
+        "types": [{"id": "troop", "names": {"en": "Troop"}}],
+        "traits": [
+            {"id": "melee", "names": {"en": "Melee"}},
+            {"id": "one-target", "names": {"en": "One-Target"}},
+        ],
+        "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
+    }
+
     with patch("scripts.fetch_method.requests.get", return_value=mock_response):
         out_file = tmp_path / "units.json"
+        cat_file = tmp_path / "categories.json"
+        cat_file.write_text(json.dumps(categories))
         dummy_details = {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "info"}
         with patch.object(fetch_method, "OUT_PATH", out_file), \
+             patch.object(fetch_method, "CATEGORIES_PATH", cat_file), \
              patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()
             data = json.loads(Path(out_file).read_text(encoding="utf-8"))
@@ -28,14 +42,14 @@ def test_fetch_units_writes_json(tmp_path):
     assert data == [{
         "id": "footman",
         "name": "Footman",
-        "faction": "Alliance",
-        "type": "Troop",
+        "faction_ids": ["alliance"],
+        "type_id": "troop",
         "cost": 2,
         "image": "footman.png",
         "damage": 10,
         "health": 20,
         "dps": 5.0,
-        "speed": "Slow",
-        "traits": ["Melee", "One-Target"],
+        "speed_id": "slow",
+        "trait_ids": ["melee", "one-target"],
         "details": dummy_details,
     }]


### PR DESCRIPTION
## Summary
- add data/categories.json with factions, types, traits and speeds
- map scraped text to IDs in `fetch_method.py`
- adjust tests for new output format
- update README with new files and fields

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f88ab4e4832f9251f00874e9d5a3