### PR TITLE
Add translation support for categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,19 @@ Die Tests lassen sich mit [pytest](https://pytest.org) ausführen:
 pip install -r requirements.txt
 pytest
 ```
+
+## Contributing translations
+
+The names of factions and other categories are defined in
+`data/categories.json`.  Each entry contains an `id` and a `names`
+dictionary with language codes as keys.  The scraper currently reads only the
+English value (`names["en"]`), but you can provide translations for additional
+languages.  To contribute a translation, add or update the appropriate
+language key.  For example:
+
+```json
+{ "id": "alliance", "names": { "en": "Alliance", "de": "Allianz" } }
+```
+
+Please keep the English text intact so the parser can continue to resolve the
+categories correctly.

--- a/data/categories.json
+++ b/data/categories.json
@@ -1,0 +1,8 @@
+[
+  {"id": "alliance", "names": {"en": "Alliance", "de": ""}},
+  {"id": "horde", "names": {"en": "Horde", "de": ""}},
+  {"id": "blackrock", "names": {"en": "Blackrock", "de": ""}},
+  {"id": "beast", "names": {"en": "Beast", "de": ""}},
+  {"id": "cenarion", "names": {"en": "Cenarion", "de": ""}},
+  {"id": "undead", "names": {"en": "Undead", "de": ""}}
+]

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -3,8 +3,35 @@ import requests
 from bs4 import BeautifulSoup
 from pathlib import Path
 
+CATEGORIES_PATH = Path(__file__).parent.parent / "data" / "categories.json"
+
 BASE_URL = "https://www.method.gg/warcraft-rumble/minis"
 OUT_PATH = Path(__file__).parent.parent / "data" / "units.json"
+
+
+def load_categories() -> list:
+    """Load known categories from :data:`data/categories.json`."""
+
+    if not CATEGORIES_PATH.exists():
+        return []
+    with open(CATEGORIES_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+_CATEGORIES = load_categories()
+_CATEGORIES_EN = {c.get("names", {}).get("en"): c for c in _CATEGORIES if c.get("names")}
+
+
+def resolve_category(name: str) -> str:
+    """Return the English label for a category.
+
+    If the category is unknown, the input string is returned.  This allows
+    additional languages to be added in ``categories.json`` without changing
+    the scraping logic.
+    """
+
+    entry = _CATEGORIES_EN.get(name)
+    return entry["names"]["en"] if entry else name
 
 
 def fetch_unit_details(url: str) -> dict:
@@ -124,7 +151,9 @@ def fetch_units():
 
     for card in cards:
         name = card.get("data-name", "?")
-        faction = card.get("data-family", "?")
+        raw_factions = card.get("data-family", "?")
+        factions = [resolve_category(f.strip()) for f in raw_factions.split(',') if f.strip()]
+        faction = ",".join(factions)
         unit_type = card.get("data-type", "?")
         cost_attr = card.get("data-cost")
         cost = int(cost_attr) if cost_attr is not None else None


### PR DESCRIPTION
## Summary
- support translation metadata in `data/categories.json`
- document how to contribute translations in README
- read categories through `resolve_category` in `fetch_method.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f8980f70832fb7843683db8f9f25