### PR TITLE
Fix speed parsing for spells

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Dieses Skript lädt die aktuellen Minis von [method.gg](https://www.method.gg/warcraft-rumble/minis) und speichert sie als `data/units.json`.
 Der Scraper durchsucht dabei alle `div.mini-wrapper` Elemente auf der Minis-Liste und ruft anschließend die jeweilige Detailseite auf.
 Neben den Basisdaten werden dadurch auch Schaden, Lebenspunkte, DPS, Geschwindigkeit und Traits sowie weitere Detailinformationen erfasst.
-Zauber oder stationäre Einheiten besitzen keinen Geschwindigkeitswert; das Feld wird in der JSON-Datei daher als `null` gespeichert.
+Zauber oder stationäre Einheiten besitzen keinen Geschwindigkeitswert; das Feld wird in der JSON-Datei daher als `null` gespeichert. Auch `speed_id` ist in diesen Fällen `null`.
 
 ## Setup
 

--- a/data/units.json
+++ b/data/units.json
@@ -264,7 +264,7 @@
     "damage": 75,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "cycle",
       "elemental",
@@ -596,7 +596,7 @@
     "damage": 500,
     "health": 0,
     "dps": 100.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "frost",
@@ -776,7 +776,7 @@
     "damage": 176,
     "health": 1700,
     "dps": 70.4,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "tank",
       "attack-stun",
@@ -942,7 +942,7 @@
     "damage": 150,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "cycle",
       "elemental",
@@ -1072,7 +1072,7 @@
     "damage": 0,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "spell",
       "aoe"
@@ -1349,7 +1349,7 @@
     "damage": 160,
     "health": 0,
     "dps": 30.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "spell",
@@ -1580,7 +1580,7 @@
     "damage": 332,
     "health": 2340,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "shapeshift",
@@ -1705,7 +1705,7 @@
     "damage": 1095,
     "health": 0,
     "dps": 154.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "poisonous",
@@ -1840,7 +1840,7 @@
     "damage": 580,
     "health": 0,
     "dps": 36.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "eclipse",
@@ -1970,7 +1970,7 @@
     "damage": 0,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "spell",
       "aoe"
@@ -3054,7 +3054,7 @@
     "damage": 150,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "spell",
@@ -3234,7 +3234,7 @@
     "damage": 200,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "spell",
@@ -4143,7 +4143,7 @@
     "damage": 0,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "spell",
       "aoe"
@@ -4311,7 +4311,7 @@
     "damage": 170,
     "health": 220,
     "dps": 113.3,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "ranged",
@@ -4433,7 +4433,7 @@
     "damage": 150,
     "health": 1800,
     "dps": 75.0,
-    "speed_id": "stationary",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "resistant",
@@ -4574,7 +4574,7 @@
     "damage": 460,
     "health": 1720,
     "dps": 82.3,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "dismounts",
@@ -4828,7 +4828,7 @@
     "damage": 0,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "cycle",
       "spell",
@@ -5766,7 +5766,7 @@
     "damage": 0,
     "health": 0,
     "dps": 0.0,
-    "speed_id": "znull",
+    "speed_id": null,
     "trait_ids": [
       "elemental",
       "cycle",

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -146,7 +146,8 @@ def fetch_units():
     and traits for each entry. For every mini the corresponding detail page
     is fetched via :func:`fetch_unit_details` and merged into the output.
     Spells oder stationäre Einheiten besitzen keinen ``speed``-Wert; in der
-    JSON-Datei erscheint dieser daher als ``null``.
+    JSON-Datei erscheint dieser daher als ``null``. Ihr ``speed_id``-Eintrag
+    ist ebenfalls ``null``.
     All collected units are written to ``data/units.json``. The file will be
     created if it does not exist and overwritten otherwise.
 
@@ -181,9 +182,10 @@ def fetch_units():
         speed_attr = card.get("data-speed")
         if speed_attr is None or speed_attr.strip() == "" or speed_attr == "Znull":
             speed = None
+            speed_val = None
         else:
             speed = speed_attr
-        speed_val = card.get("data-speed")
+            speed_val = speed_attr
         traits_attr = card.get("data-traits", "")
         trait_names = [t.strip() for t in traits_attr.split(",") if t.strip()]
 
@@ -201,7 +203,10 @@ def fetch_units():
         faction_ids = [cats["faction"].get(f, f.lower()) for f in faction_val.split(",") if f]
         trait_ids = [cats["trait"].get(t, t.lower().replace(" ", "-")) for t in trait_names]
         type_id = cats["type"].get(unit_type, unit_type.lower())
-        speed_id = cats["speed"].get(speed_val, speed_val.lower()) if speed_val else None
+        if speed_val and speed_val != "Stationary":
+            speed_id = cats["speed"].get(speed_val, speed_val.lower())
+        else:
+            speed_id = None
 
         unit_data = {
             "id": unit_id,


### PR DESCRIPTION
## Summary
- normalize `data-speed` in the scraper
- treat stationary units like spells and skip `speed_id`
- document the `speed_id` behaviour
- update generated `units.json`

## Testing
- `pytest -q`
- `python scripts/fetch_method.py`

------
https://chatgpt.com/codex/tasks/task_e_685900beb258832fb50416cc1de9c099