### PR TITLE
Update fetch_unit_details to strip bonus prefix

### DIFF
--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -35,7 +35,9 @@ def fetch_unit_details(url: str) -> dict:
 
     The returned dictionary contains the sections ``core_trait``,
     ``stats``, ``traits``, ``talents`` and ``advanced_info`` extracted
-    from the detail page.
+    from the detail page.  If present, the optional ``army_bonus_slots``
+    field lists the available army bonus slots for the bottom row and
+    those lines are removed from ``advanced_info``.
     """
 
     response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
@@ -129,7 +131,7 @@ def fetch_unit_details(url: str) -> dict:
                             break
                         army_bonus_slots.append(next_line.strip())
                         j += 1
-                    del lines[idx + 1 : j]
+                    del lines[idx:j]
                     break
             details["advanced_info"] = "\n".join(lines)
             if army_bonus_slots:

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -81,3 +81,29 @@ def test_fetch_units_handles_missing_speed(tmp_path, speed_value):
             data = json.loads(Path(out_file).read_text(encoding="utf-8"))
 
     assert data[0]["speed"] is None
+
+
+def test_fetch_unit_details_army_bonus_slots_removed():
+    html = """
+        <div class=\"mini-section\">
+            <h2>Advanced Mini Information</h2>
+            <div class=\"mini-content\">
+                <p>Available army bonus slots for the bottom row</p>
+                <p>Cycle</p>
+                <p>Tank</p>
+                <p>Without a Wildcard slot, Cairne cannot buff</p>
+                <p>Shockwave applies a 1-second Stun</p>
+            </div>
+        </div>
+    """
+
+    mock_response = Mock(status_code=200, text=html)
+
+    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+        details = fetch_method.fetch_unit_details("url")
+
+    assert details["army_bonus_slots"] == ["Cycle", "Tank"]
+    assert details["advanced_info"] == (
+        "Without a Wildcard slot, Cairne cannot buff\nShockwave applies a 1-second Stun"
+    )
+    assert "Available army bonus slots" not in details["advanced_info"]


### PR DESCRIPTION
## Summary
- remove bottom row prefix from `advanced_info` in `fetch_unit_details`
- document new behaviour in `fetch_unit_details`
- test that the prefix line is absent and slots are captured

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590212d6ec832fbc133d76dc6146b4