### PR TITLE
Fix README example and field descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 Dieses Skript lädt die aktuellen Minis von [method.gg](https://www.method.gg/warcraft-rumble/minis) und speichert sie als `data/units.json`.
 Der Scraper durchsucht dabei alle `div.mini-wrapper` Elemente auf der Minis-Liste und ruft anschließend die jeweilige Detailseite auf.
-Neben den Basisdaten werden dadurch auch Schaden, Lebenspunkte, DPS, Geschwindigkeit und Traits sowie weitere Detailinformationen erfasst.
-Zauber oder stationäre Einheiten besitzen keinen Geschwindigkeitswert; das Feld wird in der JSON-Datei daher als `null` gespeichert. Auch `speed_id` ist in diesen Fällen `null`.
+Neben den Basisdaten werden dadurch auch Schaden, Lebenspunkte, DPS,
+Geschwindigkeit und Traits sowie weitere Detailinformationen erfasst.
+Zauber oder stationäre Einheiten besitzen keinen Geschwindigkeitswert; in der
+JSON-Datei erscheint daher `"speed": null` und auch `speed_id` ist `null`.
+Bei allen anderen Einheiten wird `speed` weggelassen; stattdessen verweist
+`speed_id` auf die jeweilige Geschwindigkeitskategorie.
 
 ## Setup
 
@@ -36,23 +40,10 @@ Ein Auszug aus `units.json` könnte folgendermaßen aussehen:
 
 Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Dateien
 `data/units.json` und `data/categories.json` automatisch aktualisiert.
-    "speed": "Slow",
-    "traits": ["Melee", "One-Target"],
-    "details": {
-      "core_trait": {},
-      "stats": {},
-      "traits": [],
-      "talents": [],
-      "advanced_info": "...",
-      "army_bonus_slots": []
-    }
-  }
-]
-```
 
-Das optionale Feld `army_bonus_slots` enthält eine Liste der Boni, die eine
-Einheit in der unteren Reihe des Armeefensters gewähren kann, sofern diese
-Information auf der Detailseite vorhanden ist.
+Das optionale Feld `army_bonus_slots` listet die Boni, die eine Einheit in der
+unteren Reihe des Armeefensters gewähren kann. Sind solche Angaben vorhanden,
+werden sie aus `advanced_info` entfernt und in `army_bonus_slots` gespeichert.
 
 Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Datei `data/units.json` automatisch aktualisiert.
 


### PR DESCRIPTION
## Summary
- remove stale JSON block from README example
- clarify speed fields and army bonus handling in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591cb145fc832fb7f597d56f9c10f1