### PR TITLE
Map core traits to IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Ein Auszug aus `units.json` könnte folgendermaßen aussehen:
     "faction_ids": ["alliance"],
     "trait_ids": ["melee", "one-target"],
     "details": {
-      "core_trait": {},
+      "core_trait": {"attack_id": "aoe", "type_id": "melee"},
       "stats": {},
       "traits": [],
       "talents": [
@@ -49,6 +49,8 @@ Ein Auszug aus `units.json` könnte folgendermaßen aussehen:
 Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Dateien
 `data/units.json` und `data/categories.json` automatisch aktualisiert.
 Trait descriptions are stored in `data/categories.json` under the `descriptions` field.
+The `core_trait` object of each unit lists `attack_id` and `type_id`,
+which map to the same trait IDs used in `trait_ids`.
 
 Das optionale Feld `army_bonus_slots` listet die Boni, die eine Einheit in der
 unteren Reihe des Armeefensters gewähren kann. Sind solche Angaben vorhanden,

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -54,7 +54,9 @@ def fetch_unit_details(url: str) -> dict:
 
     The returned dictionary contains the sections ``core_trait``, ``stats``,
     ``traits``, ``talents`` and ``advanced_info`` extracted from the detail
-    page. ``traits`` now contains only trait IDs which are resolved via
+    page. ``core_trait`` stores ``attack_id`` and ``type_id`` which reference
+    trait IDs from ``data/categories.json``. ``traits`` contains only trait IDs
+    which are resolved via
     :func:`load_categories`.  Talent names and descriptions are stored as
     language dictionaries, e.g. ``{"name": {"en": "Fresh Meat"}}``.  If
     present, the optional ``army_bonus_slots`` field lists the available army
@@ -78,16 +80,18 @@ def fetch_unit_details(url: str) -> dict:
     info_section = find_section("Mini Information")
     core_trait = {}
     if info_section:
+        cat_map = load_categories()["trait"]
         for tile in info_section.select(".mini-details-tile"):
             label_elem = tile.select_one(".detail-label")
             info_elem = tile.select_one(".detail-info")
             label = label_elem.get_text(strip=True) if label_elem else None
             value = info_elem.get_text(strip=True) if info_elem else None
-            if label and label.startswith("Core Trait"):
+            if label and value and label.startswith("Core Trait"):
+                trait_id = cat_map.get(value, value.lower().replace(" ", "-"))
                 if "Attack" in label:
-                    core_trait["attack"] = value
+                    core_trait["attack_id"] = trait_id
                 elif "Type" in label:
-                    core_trait["type"] = value
+                    core_trait["type_id"] = trait_id
     if core_trait:
         details["core_trait"] = core_trait
 

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -163,3 +163,35 @@ def test_fetch_unit_details_returns_trait_ids():
         details = fetch_method.fetch_unit_details("url")
 
     assert details["traits"] == ["tank"]
+
+
+def test_fetch_unit_details_core_trait_ids():
+    html = """
+        <div class=\"mini-section\">
+            <h2>Mini Information</h2>
+            <div class=\"mini-details-tile\">
+                <div class=\"detail-label\">Core Trait Attack</div>
+                <div class=\"detail-info\">AoE</div>
+            </div>
+            <div class=\"mini-details-tile\">
+                <div class=\"detail-label\">Core Trait Type</div>
+                <div class=\"detail-info\">Melee</div>
+            </div>
+        </div>
+    """
+    mock_response = Mock(status_code=200, text=html)
+
+    with patch("scripts.fetch_method.requests.get", return_value=mock_response), \
+         patch(
+             "scripts.fetch_method.load_categories",
+             return_value={
+                 "faction": {},
+                 "type": {},
+                 "trait": {"AoE": "aoe", "Melee": "melee"},
+                 "speed": {},
+                 "trait_desc": {},
+             },
+         ):
+        details = fetch_method.fetch_unit_details("url")
+
+    assert details["core_trait"] == {"attack_id": "aoe", "type_id": "melee"}


### PR DESCRIPTION
## Summary
- convert core trait names to trait IDs in `fetch_unit_details`
- document new core_trait format in README
- verify core trait IDs via new test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595d3283e0832faf47ae7bebdd0451