### PR TITLE
Preserve translations on rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ For example:
 Please keep the English text intact so the parser can continue to resolve the
 categories correctly.
 
+Wenn `scripts/fetch_method.py` erneut ausgeführt wird, übernimmt der Scraper
+alle vorhandenen Sprachschlüssel (außer `en`) aus `data/units.json` automatisch.
+Eigene Übersetzungen müssen daher nicht nach jedem Update neu eingetragen
+werden.
+
 Trait descriptions are stored in the same file.  Each trait entry has a
 ``descriptions`` object with language codes as keys.  The unit data only lists
 trait IDs in ``details['traits']``; refer to ``categories.json`` to look up the

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -258,6 +258,21 @@ def fetch_units():
 
         all_units.append(unit_data)
 
+    existing_names = {}
+    if OUT_PATH.exists():
+        try:
+            with open(OUT_PATH, encoding="utf-8") as f:
+                for unit in json.load(f):
+                    existing_names[unit.get("id")] = unit.get("names", {})
+        except (json.JSONDecodeError, OSError):
+            existing_names = {}
+
+    for unit in all_units:
+        old_names = existing_names.get(unit["id"], {})
+        for lang, text in old_names.items():
+            if lang != "en" and lang not in unit["names"]:
+                unit["names"][lang] = text
+
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(OUT_PATH, "w", encoding="utf-8") as f:
         json.dump(all_units, f, indent=2, ensure_ascii=False)

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -71,6 +71,42 @@ def test_fetch_units_writes_json(tmp_path):
     }]
 
 
+def test_fetch_units_preserves_translations(tmp_path):
+    html = """
+        <div class=\"mini-wrapper\" data-name=\"Footman\" data-family=\"Alliance\" data-type=\"Troop\" data-cost=\"2\" data-damage=\"10\" data-health=\"20\" data-dps=\"5\" data-speed=\"Slow\" data-traits=\"Melee,One-Target\">
+            <a class=\"mini-link\" href=\"/warcraft-rumble/minis/footman\">
+                <img src=\"footman.png\" />
+            </a>
+        </div>
+    """
+    mock_response = Mock(status_code=200, text=html)
+
+    categories = {
+        "factions": [{"id": "alliance", "names": {"en": "Alliance"}}],
+        "types": [{"id": "troop", "names": {"en": "Troop"}}],
+        "traits": [],
+        "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
+    }
+
+    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+        out_file = tmp_path / "units.json"
+        cat_file = tmp_path / "categories.json"
+        cat_file.write_text(json.dumps(categories))
+        existing = [{
+            "id": "footman",
+            "names": {"en": "Old", "de": "Fußmann"},
+        }]
+        out_file.write_text(json.dumps(existing))
+        dummy_details = {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "info"}
+        with patch.object(fetch_method, "OUT_PATH", out_file), \
+             patch.object(fetch_method, "CATEGORIES_PATH", cat_file), \
+             patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
+            fetch_method.fetch_units()
+            data = json.loads(out_file.read_text(encoding="utf-8"))
+
+    assert data[0]["names"] == {"en": "Footman", "de": "Fußmann"}
+
+
 @pytest.mark.parametrize("speed_value", ["", "Znull"])
 def test_fetch_units_handles_missing_speed_id(tmp_path, speed_value):
     html = f"""


### PR DESCRIPTION
## Summary
- keep existing translation keys from `units.json` when re-running `fetch_method`
- note in README that translations are automatically carried over
- ensure translations survive in a new regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598b909838832fba9e40e2faf97828