### PR TITLE
Add incremental update logic for units

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ For example:
 Please keep the English text intact so the parser can continue to resolve the
 categories correctly.
 
-Wenn `scripts/fetch_method.py` erneut ausgeführt wird, übernimmt der Scraper
-alle vorhandenen Sprachschlüssel (außer `en`) aus `data/units.json` automatisch.
-Eigene Übersetzungen müssen daher nicht nach jedem Update neu eingetragen
-werden.
+Wird `scripts/fetch_method.py` erneut ausgeführt, liest der Scraper die
+bestehende Datei `data/units.json` ein und prüft für jede Mini, ob sich
+relevante Werte geändert haben. Nur geänderte Einheiten werden aktualisiert,
+unveränderte Datensätze bleiben unverändert erhalten. Dabei übernimmt das
+Skript alle vorhandenen Sprachschlüssel (außer `en`) automatisch, sodass eigene
+Übersetzungen nicht nach jedem Update neu eingetragen werden müssen.
 
 Trait descriptions are stored in the same file.  Each trait entry has a
 ``descriptions`` object with language codes as keys.  The unit data only lists


### PR DESCRIPTION
## Summary
- keep old unit data unless scraped data changed
- document how unchanged units are retained
- test for skipped and updated units

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598f1935f0832f9060d042a2336971