### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Bei allen anderen Einheiten wird `speed` weggelassen; stattdessen verweist
 ## Setup
 
 ```bash
-pip install -r requirements.txt
+./setup.sh
 python scripts/fetch_method.py
 ```
+
+`setup.sh` installiert alle Abhängigkeiten aus `requirements.txt`.
 
 Der Aufruf legt die Dateien `data/units.json` und `data/categories.json` an.
 `units.json` enthält die Minis, `categories.json` die verfügbaren Fraktionen,

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Install required Python packages
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add a simple setup script that installs requirements
- document setup script usage in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685992e5776c832fb1ee9374f7f00ee6