### PR TITLE
Handle Stationary speed attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Neben den Basisdaten werden dadurch auch Schaden, Lebenspunkte, DPS,
 Geschwindigkeit und Traits sowie weitere Detailinformationen erfasst.
 Zauber oder stationäre Einheiten besitzen keinen Geschwindigkeitswert; in der
 JSON-Datei erscheint daher `"speed": null` und auch `speed_id` ist `null`.
+Falls das `speed`-Attribut den Wert `"Stationary"` trägt, wird dieser ebenfalls
+als fehlende Geschwindigkeit behandelt und als `null` gespeichert.
 Bei allen anderen Einheiten wird `speed` weggelassen; stattdessen verweist
 `speed_id` auf die jeweilige Geschwindigkeitskategorie.
 

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -7,6 +7,8 @@ from bs4 import BeautifulSoup
 BASE_URL = "https://www.method.gg/warcraft-rumble/minis"
 OUT_PATH = Path(__file__).parent.parent / "data" / "units.json"
 CATEGORIES_PATH = Path(__file__).parent.parent / "data" / "categories.json"
+# Value used by method.gg for immobile units.
+STATIONARY = "Stationary"
 
 
 def load_categories() -> dict:
@@ -248,7 +250,13 @@ def fetch_units():
         dps_attr = card.get("data-dps")
         dps = float(dps_attr) if dps_attr is not None else None
         speed_attr = card.get("data-speed")
-        if speed_attr is None or speed_attr.strip() == "" or speed_attr == "Znull":
+        if (
+            speed_attr is None
+            or speed_attr.strip() == ""
+            or speed_attr == "Znull"
+            or speed_attr == STATIONARY
+        ):
+            # Treat "Stationary" the same as a missing speed value
             speed = None
             speed_val = None
         else:

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -200,7 +200,7 @@ def test_fetch_units_updates_changed_unit(tmp_path):
     assert data[0]["names"]["de"] == "Fußmann"
 
 
-@pytest.mark.parametrize("speed_value", ["", "Znull"])
+@pytest.mark.parametrize("speed_value", ["", "Znull", fetch_method.STATIONARY])
 def test_fetch_units_handles_missing_speed_id(tmp_path, speed_value):
     html = f"""
         <div class=\"mini-wrapper\" data-name=\"Spell\" data-family=\"Beast\" data-type=\"Spell\" data-cost=\"1\" data-damage=\"0\" data-health=\"0\" data-dps=\"0\" data-speed=\"{speed_value}\" data-traits=\"\">
@@ -217,11 +217,14 @@ def test_fetch_units_handles_missing_speed_id(tmp_path, speed_value):
             data = json.loads(Path(out_file).read_text(encoding="utf-8"))
 
     assert data[0]["speed_id"] is None
+    if speed_value == fetch_method.STATIONARY:
+        assert data[0]["speed"] is None
 
 
-@pytest.mark.parametrize("speed_value", ["", "Znull"])
+@pytest.mark.parametrize("speed_value", ["", "Znull", fetch_method.STATIONARY])
 def test_speed_id_is_none_when_speed_empty_or_znull(tmp_path, speed_value):
-    """Ensure speed_id is None when the speed attribute is empty or 'Znull'."""
+    """Ensure speed_id is None when the speed attribute is empty, 'Znull' or
+    'Stationary'."""
     html = f"""
         <div class=\"mini-wrapper\" data-name=\"Spell\" data-family=\"Beast\" da
 ta-type=\"Spell\" data-cost=\"1\" data-damage=\"0\" data-health=\"0\" data-dps=\"0\" data-speed=\"{speed_value}\" data-traits=\"\">


### PR DESCRIPTION
## Summary
- treat the value `Stationary` as missing speed in `fetch_method`
- cover the new behavior in unit tests
- note Stationary handling in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685991c79804832fb1827db7403a245c