### PR TITLE
Handle requests exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ python scripts/fetch_method.py
 ```
 
 Der Aufruf legt die Dateien `data/units.json` und `data/categories.json` an.
+Tritt beim Abrufen ein Netzwerkfehler auf, gibt das Skript eine
+Fehlermeldung aus und beendet sich mit dem Code `1`.
 `units.json` enthält die Minis, `categories.json` die verfügbaren Fraktionen,
 Typen, Traits und Geschwindigkeiten.
 Ein Auszug aus `units.json` könnte folgendermaßen aussehen:

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import sys
 
 import requests
 from bs4 import BeautifulSoup
@@ -95,10 +96,16 @@ def fetch_unit_details(url: str) -> dict:
     language dictionaries, e.g. ``{"name": {"en": "Fresh Meat"}}``.  If
     present, the optional ``army_bonus_slots`` field lists the available army
     bonus slots for the bottom row and those lines are removed from
-    ``advanced_info``.
+    ``advanced_info``.  Wenn beim Abruf ein Netzwerkfehler auftritt,
+    gibt die Funktion eine Fehlermeldung aus und beendet das Skript
+    mit dem Rückgabecode ``1``.
     """
 
-    response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
+    try:
+        response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
+    except requests.RequestException as exc:
+        print(f"Fehler beim Abrufen von {url}: {exc}")
+        sys.exit(1)
     if response.status_code != 200:
         raise Exception(f"Fehler beim Abrufen: {response.status_code}")
 
@@ -216,14 +223,20 @@ def fetch_units():
     keys.  Existing entries from ``data/units.json`` are loaded and compared
     to the scraped data. Only minis with changed values are updated in the
     output; unchanged entries remain verbatim. The file will be created if it
-    does not exist.
+    does not exist.  Scheitert der Abruf der Übersichtsseite aufgrund
+    eines Netzwerkfehlers, gibt die Funktion eine Meldung aus und beendet
+    das Skript mit dem Rückgabecode ``1``.
 
     Returns:
         None: Writes the JSON file and prints progress information.
     """
 
     print(f"Starte Abruf von {BASE_URL} ...")
-    response = requests.get(BASE_URL, headers={"User-Agent": "Mozilla/5.0"})
+    try:
+        response = requests.get(BASE_URL, headers={"User-Agent": "Mozilla/5.0"})
+    except requests.RequestException as exc:
+        print(f"Fehler beim Abrufen von {BASE_URL}: {exc}")
+        sys.exit(1)
     if response.status_code != 200:
         raise Exception(f"Fehler beim Abrufen: {response.status_code}")
 

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -2,6 +2,7 @@ import json
 import sys
 from pathlib import Path
 from unittest.mock import patch, Mock
+import requests
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -324,3 +325,15 @@ def test_fetch_unit_details_core_trait_ids():
         details = fetch_method.fetch_unit_details("url")
 
     assert details["core_trait"] == {"attack_id": "aoe", "type_id": "melee"}
+
+
+def test_fetch_units_request_exception(tmp_path, capsys):
+    """Die Funktion soll bei Netzwerkfehlern mit Code 1 beenden."""
+    with patch(
+        "scripts.fetch_method.requests.get",
+        side_effect=requests.RequestException("boom"),
+    ), patch.object(fetch_method, "OUT_PATH", tmp_path / "units.json"):
+        with pytest.raises(SystemExit) as excinfo:
+            fetch_method.fetch_units()
+    assert excinfo.value.code == 1
+    assert "Fehler beim Abrufen" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- stop on network failures while fetching data
- document that the script exits with code 1 on request errors
- test that a RequestException aborts execution with the right status

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599225dcd0832f8337dd52a1f40969