### PR TITLE
Add timeout to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ python scripts/fetch_method.py
 
 Der Aufruf legt die Dateien `data/units.json` und `data/categories.json` an.
 Tritt beim Abrufen ein Netzwerkfehler auf, gibt das Skript eine
-Fehlermeldung aus und beendet sich mit dem Code `1`.
+Fehlermeldung aus und beendet sich mit dem Code `1`. Alle HTTP-Anfragen brechen
+nach zehn Sekunden ohne Antwort mit einem Timeout ab.
 `units.json` enthält die Minis, `categories.json` die verfügbaren Fraktionen,
 Typen, Traits und Geschwindigkeiten.
 Ein Auszug aus `units.json` könnte folgendermaßen aussehen:

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -100,13 +100,16 @@ def fetch_unit_details(url: str) -> dict:
     the available army bonus slots for the bottom row and those lines are
     removed from ``advanced_info``.  Wenn beim Abruf ein Netzwerkfehler
     auftritt, gibt die Funktion eine Fehlermeldung aus und beendet das Skript
-    mit dem Rückgabecode ``1``.
+    mit dem Rückgabecode ``1``. Alle HTTP-Anfragen verwenden einen Timeout von
+    zehn Sekunden, um bei ausbleibender Antwort nicht ewig zu blockieren.
     """
 
     cats = load_categories()
 
     try:
-        response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
+        response = requests.get(
+            url, headers={"User-Agent": "Mozilla/5.0"}, timeout=10
+        )
     except requests.RequestException as exc:
         print(f"Fehler beim Abrufen von {url}: {exc}")
         sys.exit(1)
@@ -229,7 +232,8 @@ def fetch_units():
     output; unchanged entries remain verbatim. The file will be created if it
     does not exist.  Scheitert der Abruf der Übersichtsseite aufgrund
     eines Netzwerkfehlers, gibt die Funktion eine Meldung aus und beendet
-    das Skript mit dem Rückgabecode ``1``.
+    das Skript mit dem Rückgabecode ``1``. Die HTTP-Abfrage der Übersichtsseite
+    bricht nach zehn Sekunden ohne Antwort mit einem Timeout ab.
 
     Returns:
         None: Writes the JSON file and prints progress information.
@@ -237,7 +241,9 @@ def fetch_units():
 
     print(f"Starte Abruf von {BASE_URL} ...")
     try:
-        response = requests.get(BASE_URL, headers={"User-Agent": "Mozilla/5.0"})
+        response = requests.get(
+            BASE_URL, headers={"User-Agent": "Mozilla/5.0"}, timeout=10
+        )
     except requests.RequestException as exc:
         print(f"Fehler beim Abrufen von {BASE_URL}: {exc}")
         sys.exit(1)

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -38,7 +38,9 @@ def test_fetch_units_writes_json(tmp_path):
         "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
     }
 
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get:
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
         cat_file.write_text(json.dumps(categories))
@@ -54,6 +56,11 @@ def test_fetch_units_writes_json(tmp_path):
              patch.object(fetch_method, "CATEGORIES_PATH", cat_file), \
              patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()
+            mock_get.assert_called_once_with(
+                fetch_method.BASE_URL,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=10,
+            )
             data = json.loads(Path(out_file).read_text(encoding="utf-8"))
 
     assert data == [{
@@ -89,7 +96,9 @@ def test_fetch_units_preserves_translations(tmp_path):
         "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
     }
 
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get:
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
         cat_file.write_text(json.dumps(categories))
@@ -103,6 +112,11 @@ def test_fetch_units_preserves_translations(tmp_path):
              patch.object(fetch_method, "CATEGORIES_PATH", cat_file), \
              patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()
+            mock_get.assert_called_once_with(
+                fetch_method.BASE_URL,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=10,
+            )
             data = json.loads(out_file.read_text(encoding="utf-8"))
 
     assert data[0]["names"] == {"en": "Footman", "de": "Fußmann"}
@@ -125,7 +139,9 @@ def test_fetch_units_skips_unchanged_unit(tmp_path):
         "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
     }
 
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get:
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
         cat_file.write_text(json.dumps(categories))
@@ -149,6 +165,11 @@ def test_fetch_units_skips_unchanged_unit(tmp_path):
              patch.object(fetch_method, "CATEGORIES_PATH", cat_file), \
              patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()
+            mock_get.assert_called_once_with(
+                fetch_method.BASE_URL,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=10,
+            )
             data = json.loads(out_file.read_text(encoding="utf-8"))
 
     assert data == existing
@@ -171,7 +192,9 @@ def test_fetch_units_updates_changed_unit(tmp_path):
         "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
     }
 
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get:
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
         cat_file.write_text(json.dumps(categories))
@@ -195,6 +218,11 @@ def test_fetch_units_updates_changed_unit(tmp_path):
              patch.object(fetch_method, "CATEGORIES_PATH", cat_file), \
              patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()
+            mock_get.assert_called_once_with(
+                fetch_method.BASE_URL,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=10,
+            )
             data = json.loads(out_file.read_text(encoding="utf-8"))
 
     assert data[0]["cost"] == 3
@@ -209,12 +237,19 @@ def test_fetch_units_handles_missing_speed_id(tmp_path, speed_value):
         </div>
     """
     mock_response = Mock(status_code=200, text=html)
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get:
         out_file = tmp_path / "units.json"
         dummy_details = {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "info"}
         with patch.object(fetch_method, "OUT_PATH", out_file), \
              patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()
+            mock_get.assert_called_once_with(
+                fetch_method.BASE_URL,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=10,
+            )
             data = json.loads(Path(out_file).read_text(encoding="utf-8"))
 
     assert data[0]["speed_id"] is None
@@ -233,12 +268,19 @@ ta-type=\"Spell\" data-cost=\"1\" data-damage=\"0\" data-health=\"0\" data-dps=\
         </div>
     """
     mock_response = Mock(status_code=200, text=html)
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get:
         out_file = tmp_path / "units.json"
         dummy_details = {"core_trait": {}, "stats": {}, "traits": [], "talents": [], "advanced_info": "info"}
         with patch.object(fetch_method, "OUT_PATH", out_file), \
              patch.object(fetch_method, "fetch_unit_details", return_value=dummy_details):
             fetch_method.fetch_units()
+            mock_get.assert_called_once_with(
+                fetch_method.BASE_URL,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=10,
+            )
             data = json.loads(Path(out_file).read_text(encoding="utf-8"))
 
     assert data[0]["speed_id"] is None
@@ -260,8 +302,13 @@ def test_fetch_unit_details_army_bonus_slots_removed():
 
     mock_response = Mock(status_code=200, text=html)
 
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response):
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get:
         details = fetch_method.fetch_unit_details("url")
+        mock_get.assert_called_once_with(
+            "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
+        )
 
     assert details["army_bonus_slots"] == ["Cycle", "Tank"]
     assert details["advanced_info"] == (
@@ -282,7 +329,9 @@ def test_fetch_unit_details_returns_trait_ids():
     """
     mock_response = Mock(status_code=200, text=html)
 
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response), \
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get, \
          patch(
              "scripts.fetch_method.load_categories",
              return_value={
@@ -294,6 +343,9 @@ def test_fetch_unit_details_returns_trait_ids():
              },
          ):
         details = fetch_method.fetch_unit_details("url")
+        mock_get.assert_called_once_with(
+            "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
+        )
 
     assert details["traits"] == ["tank"]
 
@@ -314,10 +366,12 @@ def test_fetch_unit_details_core_trait_ids():
     """
     mock_response = Mock(status_code=200, text=html)
 
-    with patch("scripts.fetch_method.requests.get", return_value=mock_response), \
-         patch(
-             "scripts.fetch_method.load_categories",
-             return_value={
+    with patch(
+        "scripts.fetch_method.requests.get", return_value=mock_response
+    ) as mock_get, \
+        patch(
+            "scripts.fetch_method.load_categories",
+            return_value={
                  "faction": {},
                  "type": {},
                  "trait": {"AoE": "aoe", "Melee": "melee"},
@@ -326,6 +380,9 @@ def test_fetch_unit_details_core_trait_ids():
              },
          ):
         details = fetch_method.fetch_unit_details("url")
+        mock_get.assert_called_once_with(
+            "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
+        )
 
     assert details["core_trait"] == {"attack_id": "aoe", "type_id": "melee"}
 
@@ -335,9 +392,12 @@ def test_fetch_unit_details_request_exception(capsys):
     with patch(
         "scripts.fetch_method.requests.get",
         side_effect=requests.RequestException("boom"),
-    ):
+    ) as mock_get:
         with pytest.raises(SystemExit) as excinfo:
             fetch_method.fetch_unit_details("url")
+        mock_get.assert_called_once_with(
+            "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
+        )
     assert excinfo.value.code == 1
     assert "Fehler beim Abrufen" in capsys.readouterr().out
 
@@ -347,8 +407,13 @@ def test_fetch_units_request_exception(tmp_path, capsys):
     with patch(
         "scripts.fetch_method.requests.get",
         side_effect=requests.RequestException("boom"),
-    ), patch.object(fetch_method, "OUT_PATH", tmp_path / "units.json"):
+    ) as mock_get, patch.object(fetch_method, "OUT_PATH", tmp_path / "units.json"):
         with pytest.raises(SystemExit) as excinfo:
             fetch_method.fetch_units()
+        mock_get.assert_called_once_with(
+            fetch_method.BASE_URL,
+            headers={"User-Agent": "Mozilla/5.0"},
+            timeout=10,
+        )
     assert excinfo.value.code == 1
     assert "Fehler beim Abrufen" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add a 10 second timeout when fetching data from method.gg
- document the timeout in the docs
- check for the timeout in the test suite

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d09c95b8832f8641d41eed005e9e