### PR TITLE
Add split faction categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ pytest
 ## Contributing translations
 
 The names of factions and other categories are defined in
-`data/categories.json`.  Each entry contains an `id` and a `names`
-dictionary with language codes as keys. Traits also have a `descriptions`
-dictionary for localized text. Unit names and talent information in
-`data/units.json` use the same structure: every textual field is a dictionary
-keyed by language code.
+`data/categories.json`. Each entry contains an `id` and a `names`
+dictionary with language codes as keys. Split-leader factions such as
+"Alliance & Undead" appear here as well and use the color of the first
+listed faction. Traits also have a `descriptions` dictionary for
+localized text. Unit names and talent information in `data/units.json`
+use the same structure: every textual field is a dictionary keyed by
+language code.
 The scraper currently reads only the English values (`names["en"]`), but you can
 provide translations for additional languages. To contribute a translation,
 add a new language key anywhere a `names` or `descriptions` dictionary appears.

--- a/data/categories.json
+++ b/data/categories.json
@@ -53,6 +53,51 @@
       },
       "icon": "/images/rumble/undead.png",
       "color": "#6D59A7"
+    },
+    {
+      "id": "alliance-undead",
+      "names": {
+        "en": "Alliance & Undead",
+        "de": "Allianz & Untote"
+      },
+      "icon": "/images/rumble/wcr_alliance_undead.png",
+      "color": "#4A8CC4"
+    },
+    {
+      "id": "alliance-cenarion",
+      "names": {
+        "en": "Alliance & Cenarion",
+        "de": "Allianz & Cenarion"
+      },
+      "icon": "/images/rumble/wcr_alliance_cenarion.png",
+      "color": "#4A8CC4"
+    },
+    {
+      "id": "horde-blackrock",
+      "names": {
+        "en": "Horde & Blackrock",
+        "de": "Horde & Schwarzfels"
+      },
+      "icon": "/images/rumble/wcr_horde_blackrock.png",
+      "color": "#BC3A28"
+    },
+    {
+      "id": "undead-horde",
+      "names": {
+        "en": "Undead & Horde",
+        "de": "Untote & Horde"
+      },
+      "icon": "/images/rumble/wcr_undead_horde.png",
+      "color": "#6D59A7"
+    },
+    {
+      "id": "undead-beast",
+      "names": {
+        "en": "Undead & Beast",
+        "de": "Untote & Bestien"
+      },
+      "icon": "/images/rumble/wcr_undead_beast.png",
+      "color": "#6D59A7"
     }
   ],
   "types": [


### PR DESCRIPTION
## Summary
- add faction entries for split leaders in `categories.json`
- document split factions in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859e16e0e9c832f82501a95e32e01dc