### PR TITLE
Introduce FetchError for network failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ python scripts/fetch_method.py
 `setup.sh` installiert alle Abhängigkeiten aus `requirements.txt`.
 
 Der Aufruf legt die Dateien `data/units.json` und `data/categories.json` an.
-Tritt beim Abrufen ein Netzwerkfehler auf, gibt das Skript eine
-Fehlermeldung aus und beendet sich mit dem Code `1`. Alle HTTP-Anfragen brechen
-nach zehn Sekunden ohne Antwort mit einem Timeout ab.
+Tritt beim Abrufen ein Netzwerkfehler auf, wird eine `FetchError`-Exception
+ausgelöst. Das Hauptprogramm fängt diese ab, gibt eine Fehlermeldung aus und
+beendet sich mit dem Code `1`. Alle HTTP-Anfragen brechen nach zehn Sekunden
+ohne Antwort mit einem Timeout ab.
 `units.json` enthält die Minis, `categories.json` die verfügbaren Fraktionen,
 Typen, Traits und Geschwindigkeiten.
 Ein Auszug aus `units.json` könnte folgendermaßen aussehen:

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -437,33 +437,31 @@ def test_fetch_unit_details_core_trait_ids():
     assert details["core_trait"] == {"attack_id": "aoe", "type_id": "melee"}
 
 
-def test_fetch_unit_details_request_exception(capsys):
+def test_fetch_unit_details_request_exception():
     """Die Funktion soll bei Netzwerkfehlern mit Code 1 beenden."""
     with patch(
         "scripts.fetch_method.requests.get",
         side_effect=requests.RequestException("boom"),
     ) as mock_get:
-        with pytest.raises(SystemExit) as excinfo:
+        with pytest.raises(fetch_method.FetchError) as excinfo:
             fetch_method.fetch_unit_details("url")
         mock_get.assert_called_once_with(
             "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
         )
-    assert excinfo.value.code == 1
-    assert "Fehler beim Abrufen" in capsys.readouterr().out
+    assert "Fehler beim Abrufen" in str(excinfo.value)
 
 
-def test_fetch_units_request_exception(tmp_path, capsys):
+def test_fetch_units_request_exception(tmp_path):
     """Die Funktion soll bei Netzwerkfehlern mit Code 1 beenden."""
     with patch(
         "scripts.fetch_method.requests.get",
         side_effect=requests.RequestException("boom"),
     ) as mock_get, patch.object(fetch_method, "OUT_PATH", tmp_path / "units.json"):
-        with pytest.raises(SystemExit) as excinfo:
+        with pytest.raises(fetch_method.FetchError) as excinfo:
             fetch_method.fetch_units()
         mock_get.assert_called_once_with(
             fetch_method.BASE_URL,
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,
         )
-    assert excinfo.value.code == 1
-    assert "Fehler beim Abrufen" in capsys.readouterr().out
+    assert "Fehler beim Abrufen" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add new `FetchError` exception for HTTP errors
- raise `FetchError` in `fetch_unit_details` and `fetch_units`
- catch `FetchError` in the CLI entry point
- adjust README and docstrings
- update tests to expect `FetchError`

## Testing
- `black scripts tests`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a866caf20832f8958a675d7b89db9