### PR TITLE
Add CLI for fetch_units and improve workflow

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -19,7 +19,11 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Fetch latest data
-        run: python scripts/fetch_method.py
+        run: |
+          python scripts/fetch_method.py \
+            --output data/units.json \
+            --categories data/categories.json \
+            --timeout 10
       - name: Commit changes
         run: |
           if [[ `git status --porcelain data/units.json` ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Command-line interface for `fetch_method.py` with `--output`, `--categories` and `--timeout` options.
+- New unit tests for CLI parsing.
+
+### Changed
+- GitHub Actions workflow uses explicit paths when updating data.
+

--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ Bei allen anderen Einheiten wird `speed` weggelassen; stattdessen verweist
 
 ```bash
 ./setup.sh
-python scripts/fetch_method.py
+python scripts/fetch_method.py \
+  --output data/units.json \
+  --categories data/categories.json \
+  --timeout 10
 ```
+
+``--output`` legt den Pfad der Ergebnisdatei fest. ``--categories`` bestimmt
+die Kategorien-Definitionen und ``--timeout`` setzt das HTTP-Timeout in
+Sekunden. Ohne Angaben werden die obigen Standardwerte verwendet.
 
 `setup.sh` installiert alle Abhängigkeiten aus `requirements.txt`.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import scripts.fetch_method as fetch_method  # noqa: E402
+
+
+def test_parse_args_defaults(tmp_path):
+    with patch.object(fetch_method, "OUT_PATH", tmp_path / "units.json"), patch.object(
+        fetch_method, "CATEGORIES_PATH", tmp_path / "categories.json"
+    ):
+        args = fetch_method.parse_args([])
+        assert Path(args.output) == tmp_path / "units.json"
+        assert Path(args.categories) == tmp_path / "categories.json"
+        assert args.timeout == 10
+
+
+def test_main_invokes_fetch_units(tmp_path):
+    args = [
+        "--output",
+        str(tmp_path / "u.json"),
+        "--categories",
+        str(tmp_path / "c.json"),
+        "--timeout",
+        "7",
+        "--log-level",
+        "DEBUG",
+    ]
+    with patch.object(fetch_method, "fetch_units") as mock_fetch:
+        fetch_method.main(args)
+        mock_fetch.assert_called_once_with(
+            out_path=Path(args[1]),
+            categories_path=Path(args[3]),
+            timeout=7,
+        )


### PR DESCRIPTION
## Summary
- add CLI with `--output`, `--categories` and `--timeout`
- update GitHub Actions to use explicit paths
- document usage options in README
- add tests for CLI parsing
- create changelog entry

## Testing
- `black scripts tests`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a89d77fe8832fbddcb7303e7b2151