### PR TITLE
Add dev requirements and pin versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 ### Added
 - Command-line interface for `fetch_method.py` with `--output`, `--categories` and `--timeout` options.
 - New unit tests for CLI parsing.
+- Development requirements file and optional `--dev` flag for `setup.sh`.
+- Section in README on updating dependencies.
 
 ### Changed
 - GitHub Actions workflow uses explicit paths when updating data.
+- Pinned package versions in `requirements.txt` and `requirements-dev.txt`.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ python scripts/fetch_method.py \
 die Kategorien-Definitionen und ``--timeout`` setzt das HTTP-Timeout in
 Sekunden. Ohne Angaben werden die obigen Standardwerte verwendet.
 
-`setup.sh` installiert alle Abhängigkeiten aus `requirements.txt`.
+`setup.sh` installiert die Bibliotheken aus `requirements.txt`. Mit
+`./setup.sh --dev` werden zusätzlich die Entwicklerwerkzeuge aus
+`requirements-dev.txt` installiert.
 
 Der Aufruf legt die Dateien `data/units.json` und `data/categories.json` an.
 Tritt beim Abrufen ein Netzwerkfehler auf, wird eine `FetchError`-Exception
@@ -110,6 +112,20 @@ Run the formatters before committing:
 black scripts tests
 flake8
 ```
+
+## Updating dependencies
+
+The versions in `requirements.txt` and `requirements-dev.txt` are pinned.
+To update a package, run `pip install -U <package>` and then freeze the
+current version into the appropriate requirements file.  After adjusting the
+files, execute the test suite:
+
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+pytest
+```
+
+Commit the updated requirements together with any code changes.
 
 ## Contributing translations
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
-black
-flake8
-pytest
+pytest==8.4.1
+black==25.1.0
+flake8==7.3.0
+coverage==7.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests
-beautifulsoup4
+requests==2.32.4
+beautifulsoup4==4.13.4

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 # Install required Python packages
 pip install -r requirements.txt
+
+if [ "$1" = "--dev" ]; then
+    # Install development tools as well
+    pip install -r requirements-dev.txt
+fi

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_setup_script_has_dev_flag():
+    content = Path("setup.sh").read_text()
+    assert "--dev" in content


### PR DESCRIPTION
## Summary
- pin versions in requirements.txt and requirements-dev.txt
- extend setup.sh with optional `--dev` install flag
- document new setup workflow and dependency updates
- note the changes in CHANGELOG
- test presence of `--dev` in setup.sh

## Testing
- `black scripts tests`
- `flake8`
- `pytest -q`
- `pip install -r requirements.txt -r requirements-dev.txt`

------
https://chatgpt.com/codex/tasks/task_e_685a8df83334832fb9373f31b79f765c