### PR TITLE
Refactor fetch_unit_details API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,7 @@
 ### Changed
 - GitHub Actions workflow uses explicit paths when updating data.
 - Pinned package versions in `requirements.txt` and `requirements-dev.txt`.
+- `fetch_unit_details` accepts a `categories` dict instead of a file path.
+- `fetch_units` loads categories once via `load_categories` and passes them to
+  `fetch_unit_details`.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Datei
 Trait descriptions are stored in `data/categories.json` under the `descriptions` field.
 The `core_trait` object of each unit lists `attack_id` and `type_id`,
 which map to the same trait IDs used in `trait_ids`.
+The helper function `fetch_unit_details()` now expects the category
+mappings as a dictionary argument so that callers can load the data only
+once with `load_categories()` and reuse it across multiple units.
 
 Das optionale Feld `army_bonus_slots` listet die Boni, die eine Einheit in der
 unteren Reihe des Armeefensters gewähren kann. Sind solche Angaben vorhanden,

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -357,7 +357,8 @@ def test_fetch_unit_details_army_bonus_slots_removed():
     with patch(
         "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get:
-        details = fetch_method.fetch_unit_details("url")
+        cats = fetch_method.load_categories()
+        details = fetch_method.fetch_unit_details("url", cats)
         mock_get.assert_called_once_with(
             "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
         )
@@ -393,7 +394,8 @@ def test_fetch_unit_details_returns_trait_ids():
             "trait_desc": {"tank": "desc"},
         },
     ):
-        details = fetch_method.fetch_unit_details("url")
+        cats = fetch_method.load_categories()
+        details = fetch_method.fetch_unit_details("url", cats)
         mock_get.assert_called_once_with(
             "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
         )
@@ -429,7 +431,8 @@ def test_fetch_unit_details_core_trait_ids():
             "trait_desc": {},
         },
     ):
-        details = fetch_method.fetch_unit_details("url")
+        cats = fetch_method.load_categories()
+        details = fetch_method.fetch_unit_details("url", cats)
         mock_get.assert_called_once_with(
             "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
         )
@@ -444,7 +447,8 @@ def test_fetch_unit_details_request_exception():
         side_effect=requests.RequestException("boom"),
     ) as mock_get:
         with pytest.raises(fetch_method.FetchError) as excinfo:
-            fetch_method.fetch_unit_details("url")
+            cats = fetch_method.load_categories()
+            fetch_method.fetch_unit_details("url", cats)
         mock_get.assert_called_once_with(
             "url", headers={"User-Agent": "Mozilla/5.0"}, timeout=10
         )


### PR DESCRIPTION
## Summary
- adjust `fetch_unit_details` to take a categories dictionary instead of a path
- load categories once in `fetch_units` and pass them through
- update tests for the new parameter
- document the change in README and changelog

## Testing
- `black scripts tests`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9707d2ec832f87de0ff5abc6cfa9