### PR TITLE
Implement logging config and session factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 - Parallel download support via `--workers`.
 - Retry logic now includes exponential backoff.
 - Coverage badge in README and CI enforces >90% coverage.
+- Logging configuration via `configure_logging()`.
+- Validation for positive integer arguments `--timeout` and `--workers`.
+- Atomic writes when saving `units.json`.
+- Warning logs when `load_categories` fails to read the file.
+- Helper `create_session` for injecting custom HTTP sessions.
+- Tests for the new behaviors.
 
 ### Changed
 - GitHub Actions workflow uses explicit paths when updating data.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ python -m wcr_data_extraction.cli \
 3. The results are written to `data/units.json` and `data/categories.json`.
 
 ``--output`` legt den Pfad der Ergebnisdatei fest. ``--categories`` bestimmt die
-Kategorien-Definitionen. ``--timeout`` setzt das HTTP-Timeout in Sekunden und
-``--workers`` steuert die Anzahl paralleler Downloads. Ohne Angaben werden die
-obigen Standardwerte verwendet.
+Kategorien-Definitionen. ``--timeout`` und ``--workers`` akzeptieren nur
+positive Ganzzahlen und setzen das HTTP-Timeout bzw. die Anzahl paralleler
+Downloads. Ohne Angaben werden die obigen Standardwerte verwendet.
 
 `setup.sh` installiert die Bibliotheken aus `requirements.txt`. Mit
 `./setup.sh --dev` werden zusätzlich die Entwicklerwerkzeuge aus
@@ -43,6 +43,9 @@ Hauptprogramm fängt diese ab, schreibt eine Fehlermeldung in das Log und
 beendet sich mit dem Code `1`. Alle HTTP-Anfragen verwenden einen gemeinsamen
 `requests.Session` mit automatischen Retries und brechen nach zehn Sekunden
 ohne Antwort mit einem Timeout ab.
+Beim Schreiben von `units.json` wird zunächst eine temporäre Datei angelegt und
+nach erfolgreichem Schreiben atomar ersetzt, sodass bei Fehlern die alte Datei
+erhalten bleibt.
 `units.json` enthält die Minis, `categories.json` die verfügbaren Fraktionen,
 Typen, Traits und Geschwindigkeiten.
 Ein Auszug aus `units.json` könnte folgendermaßen aussehen:
@@ -89,8 +92,8 @@ werden sie aus `advanced_info` entfernt und in `army_bonus_slots` gespeichert.
 ## Logging
 
 Die Skripte verwenden das Modul `logging`. Über das Argument `--log-level` oder
-die Umgebungsvariable `LOG_LEVEL` lässt sich die gewünschte Protokollstufe
-festlegen. Standardmäßig wird auf `INFO` geloggt.
+die Hilfsfunktion `configure_logging()` lässt sich die gewünschte
+Protokollstufe festlegen. Standardmäßig wird auf `INFO` geloggt.
 
 ## Tests
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from wcr_data_extraction import fetcher  # noqa: E402
+
+
+def test_load_categories_logs_warning(tmp_path, caplog):
+    bad_file = tmp_path / "cats.json"
+    bad_file.write_text("{bad}")
+    with caplog.at_level("WARNING"):
+        cats = fetcher.load_categories(bad_file)
+    assert "Could not read categories" in caplog.text
+    assert cats["faction"] == {}
+
+
+def test_load_categories_logs_unreadable(tmp_path, caplog):
+    bad_file = tmp_path / "cats.json"
+    bad_file.write_text("{}")
+    with patch("builtins.open", side_effect=OSError("fail")):
+        with caplog.at_level("WARNING"):
+            cats = fetcher.load_categories(bad_file)
+    assert "Could not read categories" in caplog.text
+    assert cats["trait"] == {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 from unittest.mock import patch
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -29,11 +30,24 @@ def test_main_invokes_fetch_units(tmp_path):
         "--log-level",
         "DEBUG",
     ]
-    with patch.object(cli, "fetch_units") as mock_fetch:
+    with patch.object(cli, "configure_logging") as mock_conf, patch.object(
+        cli, "fetch_units"
+    ) as mock_fetch:
         cli.main(args)
+        mock_conf.assert_called_once_with("DEBUG")
         mock_fetch.assert_called_once_with(
             out_path=Path(args[1]),
             categories_path=Path(args[3]),
             timeout=7,
             max_workers=1,
         )
+
+
+def test_parse_args_invalid_timeout():
+    with pytest.raises(SystemExit):
+        cli.parse_args(["--timeout", "0"])
+
+
+def test_parse_args_invalid_workers():
+    with pytest.raises(SystemExit):
+        cli.parse_args(["--workers", "-1"])

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -41,9 +41,9 @@ def test_fetch_units_writes_json(tmp_path):
         "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
     }
 
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
         cat_file.write_text(json.dumps(categories))
@@ -58,8 +58,8 @@ def test_fetch_units_writes_json(tmp_path):
         with patch.object(fetcher, "OUT_PATH", out_file), patch.object(
             fetcher, "CATEGORIES_PATH", cat_file
         ), patch.object(fetcher, "fetch_unit_details", return_value=dummy_details):
-            fetcher.fetch_units()
-            mock_get.assert_called_once_with(
+            fetcher.fetch_units(session=mock_session)
+            mock_session.get.assert_called_once_with(
                 fetcher.BASE_URL,
                 headers={"User-Agent": "Mozilla/5.0"},
                 timeout=10,
@@ -103,9 +103,9 @@ def test_fetch_units_preserves_translations(tmp_path):
         "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
     }
 
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
         cat_file.write_text(json.dumps(categories))
@@ -126,8 +126,8 @@ def test_fetch_units_preserves_translations(tmp_path):
         with patch.object(fetcher, "OUT_PATH", out_file), patch.object(
             fetcher, "CATEGORIES_PATH", cat_file
         ), patch.object(fetcher, "fetch_unit_details", return_value=dummy_details):
-            fetcher.fetch_units()
-            mock_get.assert_called_once_with(
+            fetcher.fetch_units(session=mock_session)
+            mock_session.get.assert_called_once_with(
                 fetcher.BASE_URL,
                 headers={"User-Agent": "Mozilla/5.0"},
                 timeout=10,
@@ -156,9 +156,9 @@ def test_fetch_units_skips_unchanged_unit(tmp_path):
         "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
     }
 
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
         cat_file.write_text(json.dumps(categories))
@@ -189,8 +189,8 @@ def test_fetch_units_skips_unchanged_unit(tmp_path):
         with patch.object(fetcher, "OUT_PATH", out_file), patch.object(
             fetcher, "CATEGORIES_PATH", cat_file
         ), patch.object(fetcher, "fetch_unit_details", return_value=dummy_details):
-            fetcher.fetch_units()
-            mock_get.assert_called_once_with(
+            fetcher.fetch_units(session=mock_session)
+            mock_session.get.assert_called_once_with(
                 fetcher.BASE_URL,
                 headers={"User-Agent": "Mozilla/5.0"},
                 timeout=10,
@@ -219,9 +219,9 @@ def test_fetch_units_updates_changed_unit(tmp_path):
         "speeds": [{"id": "slow", "names": {"en": "Slow"}}],
     }
 
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
         cat_file.write_text(json.dumps(categories))
@@ -252,8 +252,8 @@ def test_fetch_units_updates_changed_unit(tmp_path):
         with patch.object(fetcher, "OUT_PATH", out_file), patch.object(
             fetcher, "CATEGORIES_PATH", cat_file
         ), patch.object(fetcher, "fetch_unit_details", return_value=dummy_details):
-            fetcher.fetch_units()
-            mock_get.assert_called_once_with(
+            fetcher.fetch_units(session=mock_session)
+            mock_session.get.assert_called_once_with(
                 fetcher.BASE_URL,
                 headers={"User-Agent": "Mozilla/5.0"},
                 timeout=10,
@@ -274,9 +274,9 @@ def test_fetch_units_handles_missing_speed_id(tmp_path, speed_value):
         "</div>"
     )
     mock_response = Mock(status_code=200, text=html)
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         out_file = tmp_path / "units.json"
         dummy_details = {
             "core_trait": {},
@@ -288,8 +288,8 @@ def test_fetch_units_handles_missing_speed_id(tmp_path, speed_value):
         with patch.object(fetcher, "OUT_PATH", out_file), patch.object(
             fetcher, "fetch_unit_details", return_value=dummy_details
         ):
-            fetcher.fetch_units()
-            mock_get.assert_called_once_with(
+            fetcher.fetch_units(session=mock_session)
+            mock_session.get.assert_called_once_with(
                 fetcher.BASE_URL,
                 headers={"User-Agent": "Mozilla/5.0"},
                 timeout=10,
@@ -313,9 +313,9 @@ def test_speed_id_is_none_when_speed_empty_or_znull(tmp_path, speed_value):
         "</div>"
     )
     mock_response = Mock(status_code=200, text=html)
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         out_file = tmp_path / "units.json"
         dummy_details = {
             "core_trait": {},
@@ -327,8 +327,8 @@ def test_speed_id_is_none_when_speed_empty_or_znull(tmp_path, speed_value):
         with patch.object(fetcher, "OUT_PATH", out_file), patch.object(
             fetcher, "fetch_unit_details", return_value=dummy_details
         ):
-            fetcher.fetch_units()
-            mock_get.assert_called_once_with(
+            fetcher.fetch_units(session=mock_session)
+            mock_session.get.assert_called_once_with(
                 fetcher.BASE_URL,
                 headers={"User-Agent": "Mozilla/5.0"},
                 timeout=10,
@@ -354,12 +354,14 @@ def test_fetch_unit_details_army_bonus_slots_removed():
 
     mock_response = Mock(status_code=200, text=html)
 
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         cats = fetcher.load_categories()
-        details = fetcher.fetch_unit_details("https://example.com/unit", cats)
-        mock_get.assert_called_once_with(
+        details = fetcher.fetch_unit_details(
+            "https://example.com/unit", cats, session=mock_session
+        )
+        mock_session.get.assert_called_once_with(
             "https://example.com/unit",
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,
@@ -384,9 +386,9 @@ def test_fetch_unit_details_returns_trait_ids():
     """
     mock_response = Mock(status_code=200, text=html)
 
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get, patch(
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session), patch(
         "wcr_data_extraction.fetcher.load_categories",
         return_value={
             "faction": {},
@@ -397,8 +399,10 @@ def test_fetch_unit_details_returns_trait_ids():
         },
     ):
         cats = fetcher.load_categories()
-        details = fetcher.fetch_unit_details("https://example.com/unit", cats)
-        mock_get.assert_called_once_with(
+        details = fetcher.fetch_unit_details(
+            "https://example.com/unit", cats, session=mock_session
+        )
+        mock_session.get.assert_called_once_with(
             "https://example.com/unit",
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,
@@ -423,9 +427,9 @@ def test_fetch_unit_details_core_trait_ids():
     """
     mock_response = Mock(status_code=200, text=html)
 
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get, patch(
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session), patch(
         "wcr_data_extraction.fetcher.load_categories",
         return_value={
             "faction": {},
@@ -436,8 +440,10 @@ def test_fetch_unit_details_core_trait_ids():
         },
     ):
         cats = fetcher.load_categories()
-        details = fetcher.fetch_unit_details("https://example.com/unit", cats)
-        mock_get.assert_called_once_with(
+        details = fetcher.fetch_unit_details(
+            "https://example.com/unit", cats, session=mock_session
+        )
+        mock_session.get.assert_called_once_with(
             "https://example.com/unit",
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,
@@ -448,14 +454,15 @@ def test_fetch_unit_details_core_trait_ids():
 
 def test_fetch_unit_details_request_exception():
     """Die Funktion soll bei Netzwerkfehlern mit Code 1 beenden."""
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get",
-        side_effect=requests.RequestException("boom"),
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.side_effect = requests.RequestException("boom")
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         with pytest.raises(fetcher.FetchError) as excinfo:
             cats = fetcher.load_categories()
-            fetcher.fetch_unit_details("https://example.com/unit", cats)
-        mock_get.assert_called_once_with(
+            fetcher.fetch_unit_details(
+                "https://example.com/unit", cats, session=mock_session
+            )
+        mock_session.get.assert_called_once_with(
             "https://example.com/unit",
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,
@@ -466,13 +473,15 @@ def test_fetch_unit_details_request_exception():
 def test_fetch_unit_details_http_error():
     """Bei HTTP-Fehlern soll eine FetchError mit Statuscode entstehen."""
     mock_response = Mock(status_code=404, text="not found")
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get:
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
         with pytest.raises(fetcher.FetchError) as excinfo:
             cats = fetcher.load_categories()
-            fetcher.fetch_unit_details("https://example.com/unit", cats)
-        mock_get.assert_called_once_with(
+            fetcher.fetch_unit_details(
+                "https://example.com/unit", cats, session=mock_session
+            )
+        mock_session.get.assert_called_once_with(
             "https://example.com/unit",
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,
@@ -482,13 +491,14 @@ def test_fetch_unit_details_http_error():
 
 def test_fetch_units_request_exception(tmp_path):
     """Die Funktion soll bei Netzwerkfehlern mit Code 1 beenden."""
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get",
-        side_effect=requests.RequestException("boom"),
-    ) as mock_get, patch.object(fetcher, "OUT_PATH", tmp_path / "units.json"):
+    mock_session = Mock()
+    mock_session.get.side_effect = requests.RequestException("boom")
+    with patch.object(
+        fetcher, "create_session", return_value=mock_session
+    ), patch.object(fetcher, "OUT_PATH", tmp_path / "units.json"):
         with pytest.raises(fetcher.FetchError) as excinfo:
-            fetcher.fetch_units()
-        mock_get.assert_called_once_with(
+            fetcher.fetch_units(session=mock_session)
+        mock_session.get.assert_called_once_with(
             fetcher.BASE_URL,
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,
@@ -499,12 +509,14 @@ def test_fetch_units_request_exception(tmp_path):
 def test_fetch_units_http_error(tmp_path):
     """Die Funktion soll bei HTTP-Fehlern eine FetchError werfen."""
     mock_response = Mock(status_code=500, text="")
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get, patch.object(fetcher, "OUT_PATH", tmp_path / "units.json"):
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(
+        fetcher, "create_session", return_value=mock_session
+    ), patch.object(fetcher, "OUT_PATH", tmp_path / "units.json"):
         with pytest.raises(fetcher.FetchError) as excinfo:
-            fetcher.fetch_units()
-        mock_get.assert_called_once_with(
+            fetcher.fetch_units(session=mock_session)
+        mock_session.get.assert_called_once_with(
             fetcher.BASE_URL,
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,
@@ -514,3 +526,30 @@ def test_fetch_units_http_error(tmp_path):
 
 def test_session_retry_adapter():
     assert fetcher.adapter.max_retries.total == 3
+
+
+def test_fetch_units_atomic_write(tmp_path):
+    html = "<div class='mini-wrapper'></div>"
+    mock_response = Mock(status_code=200, text=html)
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        out_file = tmp_path / "units.json"
+        out_file.write_text("old")
+        with patch.object(fetcher, "OUT_PATH", out_file), patch.object(
+            fetcher, "fetch_unit_details", return_value={}
+        ), patch.object(
+            fetcher,
+            "load_categories",
+            return_value={
+                "faction": {},
+                "type": {},
+                "trait": {},
+                "speed": {},
+                "trait_desc": {},
+            },
+        ):
+            with patch("json.dump", side_effect=ValueError("boom")):
+                with pytest.raises(ValueError):
+                    fetcher.fetch_units(session=mock_session)
+        assert out_file.read_text() == "old"

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -11,18 +11,16 @@ def test_fetch_units_uses_max_workers(tmp_path):
     html = "<div class='mini-wrapper'></div>"
     mock_response = Mock(status_code=200, text=html)
 
-    with patch(
-        "wcr_data_extraction.fetcher.SESSION.get", return_value=mock_response
-    ) as mock_get, patch(
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session), patch(
         "concurrent.futures.ThreadPoolExecutor"
-    ) as executor_mock, patch.object(
-        fetcher, "OUT_PATH", tmp_path / "u.json"
-    ):
+    ) as executor_mock, patch.object(fetcher, "OUT_PATH", tmp_path / "u.json"):
         executor = executor_mock.return_value.__enter__.return_value
         executor.map.return_value = []
-        fetcher.fetch_units(max_workers=5)
+        fetcher.fetch_units(max_workers=5, session=mock_session)
         executor_mock.assert_called_once_with(max_workers=5)
-        mock_get.assert_called_once_with(
+        mock_session.get.assert_called_once_with(
             fetcher.BASE_URL,
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=10,

--- a/wcr_data_extraction/__init__.py
+++ b/wcr_data_extraction/__init__.py
@@ -6,6 +6,8 @@ from .fetcher import (
     load_existing_units,
     is_unit_changed,
     fetch_unit_details,
+    configure_logging,
+    create_session,
 )
 
 __all__ = [
@@ -14,4 +16,6 @@ __all__ = [
     "load_existing_units",
     "is_unit_changed",
     "fetch_unit_details",
+    "configure_logging",
+    "create_session",
 ]

--- a/wcr_data_extraction/cli.py
+++ b/wcr_data_extraction/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 from pathlib import Path
 
@@ -13,11 +12,18 @@ from .fetcher import (
     CATEGORIES_PATH,
     FetchError,
     logger,
+    configure_logging,
 )
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
+
+    def positive_int(value: str) -> int:
+        ivalue = int(value)
+        if ivalue <= 0:
+            raise argparse.ArgumentTypeError("must be >0")
+        return ivalue
 
     parser = argparse.ArgumentParser(description="Fetch minis from method.gg")
     parser.add_argument(
@@ -27,10 +33,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--categories", default=str(CATEGORIES_PATH), help="Path to categories JSON"
     )
     parser.add_argument(
-        "--timeout", type=int, default=10, help="HTTP timeout in seconds"
+        "--timeout", type=positive_int, default=10, help="HTTP timeout in seconds"
     )
     parser.add_argument(
-        "--workers", type=int, default=1, help="Number of parallel workers"
+        "--workers", type=positive_int, default=1, help="Number of parallel workers"
     )
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     return parser.parse_args(argv)
@@ -40,7 +46,7 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point for the command line."""
 
     args = parse_args(argv)
-    logging.getLogger().setLevel(args.log_level.upper())
+    configure_logging(args.log_level)
     try:
         fetch_units(
             out_path=Path(args.output),


### PR DESCRIPTION
## Summary
- add `configure_logging` and `create_session`
- make `fetch_units` write atomically
- validate CLI positive int arguments
- log warnings when categories fail to load
- update docs and changelog
- add regression tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ade99d920832fa21613372d8043f9